### PR TITLE
Make credential subject id optional

### DIFF
--- a/src/application/datatypes.rs
+++ b/src/application/datatypes.rs
@@ -43,7 +43,8 @@ pub const BBS_PROOF_TYPE: &str = "BBS";
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BbsCredentialRequest {
-    pub subject: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
     pub schema: String,
     pub r#type: String,
     pub blind_signature_context: String,
@@ -116,7 +117,8 @@ pub struct AssertionProof {
 #[serde(rename_all = "camelCase")]
 pub struct BbsCredentialOffer {
     pub issuer: String,
-    pub subject: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
     pub nonce: String,
     pub credential_message_count: usize,
 }
@@ -127,7 +129,8 @@ pub struct BbsCredentialOffer {
 #[serde(rename_all = "camelCase")]
 pub struct CredentialProposal {
     pub issuer: String,
-    pub subject: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
     pub r#type: String,
     pub schema: String,
 }
@@ -244,7 +247,8 @@ impl UnfinishedBbsCredential {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CredentialSubject {
-    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     pub data: HashMap<String, String>,
 }
 

--- a/src/application/issuer.rs
+++ b/src/application/issuer.rs
@@ -127,7 +127,7 @@ impl Issuer {
     /// # Returns
     /// * `BbsCredentialOffer` - The message to be sent to the prover.
     pub fn offer_credential(
-        subject: &str,
+        subject: Option<&str>,
         issuer_did: &str,
         nquad_count: usize,
     ) -> Result<BbsCredentialOffer, Box<dyn Error>> {
@@ -135,7 +135,7 @@ impl Issuer {
 
         Ok(BbsCredentialOffer {
             issuer: issuer_did.to_owned(),
-            subject: subject.to_string(),
+            subject: subject.map(|value| value.to_string()),
             credential_message_count: nquad_count + ADDITIONAL_HIDDEN_MESSAGES_COUNT,
             nonce,
         })
@@ -234,7 +234,7 @@ impl Issuer {
         }
 
         let credential_subject = CredentialSubject {
-            id: subject_did.to_owned(),
+            id: Some(subject_did.to_owned()),
             data: credential_request.credential_values.clone(),
         };
 
@@ -518,7 +518,7 @@ mod tests {
         valid_until: Option<String>,
     ) {
         assert_eq!(&cred.issuer, ISSUER_DID);
-        assert_eq!(&cred.credential_subject.id, HOLDER_DID);
+        assert_eq!(cred.credential_subject.id, Some(HOLDER_DID.to_string()));
         assert_eq!(&cred.credential_schema.id, schema_id);
         // proof
         assert_eq!(&cred.proof.required_reveal_statements, &[1].to_vec());
@@ -546,7 +546,7 @@ mod tests {
     #[test]
     fn can_offer_credential() -> Result<(), Box<dyn Error>> {
         let proposal: CredentialProposal = serde_json::from_str(&EXAMPLE_CREDENTIAL_PROPOSAL)?;
-        let offer = Issuer::offer_credential(&proposal.subject, &ISSUER_DID, 1)?;
+        let offer = Issuer::offer_credential(proposal.subject.as_deref(), &ISSUER_DID, 1)?;
 
         assert_eq!(&offer.issuer, &ISSUER_DID);
         assert_eq!(&offer.subject, &proposal.subject);
@@ -559,7 +559,8 @@ mod tests {
         let message_count = 1;
         let (dpk, sk) = BbsIssuer::new_short_keys(None);
         let proposal: CredentialProposal = serde_json::from_str(&EXAMPLE_CREDENTIAL_PROPOSAL)?;
-        let offer = Issuer::offer_credential(&proposal.subject, &ISSUER_DID, message_count)?;
+        let offer =
+            Issuer::offer_credential(proposal.subject.as_deref(), &ISSUER_DID, message_count)?;
         let key_id = format!("{}#key-1", ISSUER_DID);
         let (credential_request, schema, nquads) = request_credential(&dpk, &offer)?;
         let valid_until = get_now_as_iso_string();
@@ -602,7 +603,8 @@ mod tests {
         let nonce_bytes = decode_base64(&SECRET_KEY, "Secret Key")?.into_boxed_slice();
         let sk = SecretKey::from(nonce_bytes);
         let proposal: CredentialProposal = serde_json::from_str(&EXAMPLE_CREDENTIAL_PROPOSAL)?;
-        let offer = Issuer::offer_credential(&proposal.subject, &ISSUER_DID, message_count)?;
+        let offer =
+            Issuer::offer_credential(proposal.subject.as_deref(), &ISSUER_DID, message_count)?;
         let key_id = format!("{}#key-1", ISSUER_DID);
         let (credential_request, schema, nquads) = request_credential(&dpk, &offer)?;
 
@@ -644,7 +646,8 @@ mod tests {
         let nonce_bytes = decode_base64(&SECRET_KEY, "Secret Key")?.into_boxed_slice();
         let sk = SecretKey::from(nonce_bytes);
         let proposal: CredentialProposal = serde_json::from_str(&EXAMPLE_CREDENTIAL_PROPOSAL)?;
-        let offer = Issuer::offer_credential(&proposal.subject, &ISSUER_DID, message_count)?;
+        let offer =
+            Issuer::offer_credential(proposal.subject.as_deref(), &ISSUER_DID, message_count)?;
         let key_id = format!("{}#key-1", ISSUER_DID);
         let (credential_request, _, nquads) = request_credential(&dpk, &offer)?;
         let unsigned_vc: UnsignedBbsCredential = serde_json::from_str(UNSIGNED_CREDENTIAL)?;
@@ -670,7 +673,8 @@ mod tests {
         let message_count = 5;
         let (dpk, sk) = BbsIssuer::new_short_keys(None);
         let proposal: CredentialProposal = serde_json::from_str(&EXAMPLE_CREDENTIAL_PROPOSAL)?;
-        let offer = Issuer::offer_credential(&proposal.subject, &ISSUER_DID, message_count)?;
+        let offer =
+            Issuer::offer_credential(proposal.subject.as_deref(), &ISSUER_DID, message_count)?;
         let key_id = format!("{}#key-1", ISSUER_DID);
         let (credential_request, schema, nquads) = request_credential(&dpk, &offer)?;
 

--- a/src/application/prover.rs
+++ b/src/application/prover.rs
@@ -59,12 +59,12 @@ impl Prover {
     /// * `CredentialProposal` - The message to be sent to an issuer
     pub fn propose_credential(
         issuer_did: &str,
-        subject_did: &str,
+        subject_did: Option<&str>,
         schema_did: &str,
     ) -> CredentialProposal {
         CredentialProposal {
             issuer: issuer_did.to_owned(),
-            subject: subject_did.to_owned(),
+            subject: subject_did.map(|value| value.to_string()),
             schema: schema_did.to_owned(),
             r#type: CREDENTIAL_PROPOSAL_TYPE.to_string(),
         }
@@ -368,7 +368,7 @@ mod tests {
         revealed_data.remove("test_property_string4");
 
         let revealed = CredentialSubject {
-            id: HOLDER_DID.to_string(),
+            id: Some(HOLDER_DID.to_string()),
             data: revealed_data,
         };
         let mut revealed_properties_map = HashMap::new();
@@ -436,8 +436,8 @@ mod tests {
 
     #[test]
     fn can_propose_credential() {
-        let proposal = Prover::propose_credential(&ISSUER_DID, &HOLDER_DID, "schemadid");
-        assert_eq!(&proposal.subject, &HOLDER_DID);
+        let proposal = Prover::propose_credential(&ISSUER_DID, Some(&HOLDER_DID), "schemadid");
+        assert_eq!(proposal.subject, Some(HOLDER_DID.to_string()));
         assert_eq!(&proposal.issuer, &ISSUER_DID);
         assert_eq!(&proposal.schema, "schemadid");
         assert_eq!(&proposal.r#type, CREDENTIAL_PROPOSAL_TYPE);

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -144,7 +144,7 @@ fn get_options() -> String {
 async fn create_credential_proposal(vade: &mut Vade) -> Result<CredentialProposal, Box<dyn Error>> {
     let proposal_payload = CreateCredentialProposalPayload {
         issuer: ISSUER_DID.to_string(),
-        subject: SUBJECT_DID.to_string(),
+        subject: Some(SUBJECT_DID.to_string()),
         schema: SCHEMA_DID.to_string(),
     };
     let proposal_payload_json = serde_json::to_string(&proposal_payload)?;
@@ -317,7 +317,7 @@ async fn create_presentation(
     let revealed_data = finished_credential.credential_subject.data.clone();
     let mut revealed_properties_schema_map = HashMap::new();
     let revealed = CredentialSubject {
-        id: HOLDER_DID.to_string(),
+        id: Some(HOLDER_DID.to_string()),
         data: revealed_data,
     };
     revealed_properties_schema_map.insert(SCHEMA_DID.to_string(), revealed);
@@ -397,7 +397,7 @@ async fn workflow_can_create_credential_proposal() -> Result<(), Box<dyn Error>>
 
     let proposal = create_credential_proposal(&mut vade).await?;
 
-    assert_eq!(&proposal.subject, &SUBJECT_DID);
+    assert_eq!(proposal.subject.as_ref(), Some(&SUBJECT_DID.to_string()));
     assert_eq!(&proposal.issuer, &ISSUER_DID);
     assert_eq!(&proposal.schema, &SCHEMA_DID.clone());
     assert_eq!(&proposal.r#type, CREDENTIAL_PROPOSAL_TYPE);
@@ -424,7 +424,6 @@ async fn workflow_can_create_credential_offer_with_proposal() -> Result<(), Box<
 
     Ok(())
 }
-
 
 #[tokio::test]
 async fn workflow_can_create_credential_request() -> Result<(), Box<dyn Error>> {
@@ -597,7 +596,10 @@ async fn workflow_can_create_finished_credential() -> Result<(), Box<dyn Error>>
     .await?;
 
     assert_eq!(&finished_credential.issuer, ISSUER_DID);
-    assert_eq!(&finished_credential.credential_subject.id, SUBJECT_DID);
+    assert_eq!(
+        finished_credential.credential_subject.id,
+        Some(SUBJECT_DID.to_string())
+    );
     assert_eq!(&finished_credential.credential_schema.id, &SCHEMA_DID);
     assert_eq!(
         &finished_credential.proof.required_reveal_statements,


### PR DESCRIPTION
## DRAFT NOTE

Wait for #15 to be merged before merging this branch.

## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Makes `id` property in credential subject optional to allow creating credentials without a predefined subject id.

## Details

<!--- HOW does it change stuff? -->

- makes `id` in `CredentialSubject` optional
- makes `id` in types and function signatures in the flow until a credential is created optional