### PR TITLE
Make verifier did optional for proof request

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,6 +6,7 @@
 
 - Refactor data structures and adjust test cases
 - make credential subject id (and respective properties in credential flow) optional
+- make the "verifierDid" optional for generating proof requests
 
 ### Fixes
 

--- a/src/application/datatypes.rs
+++ b/src/application/datatypes.rs
@@ -55,7 +55,8 @@ pub struct BbsCredentialRequest {
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BbsProofRequest {
-    pub verifier: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verifier: Option<String>,
     pub created_at: String,
     pub nonce: String,
     pub r#type: String,

--- a/src/application/verifier.rs
+++ b/src/application/verifier.rs
@@ -17,7 +17,10 @@
 use crate::{
     application::{
         datatypes::{
-            BbsProofRequest, BbsProofVerification, BbsSubProofRequest, ProofPresentation,
+            BbsProofRequest,
+            BbsProofVerification,
+            BbsSubProofRequest,
+            ProofPresentation,
             BBS_PROOF_TYPE,
         },
         utils::{decode_base64, get_now_as_iso_string},
@@ -26,8 +29,13 @@ use crate::{
     BbsPresentation,
 };
 use bbs::{
-    keys::DeterministicPublicKey, prelude::PublicKey, verifier::Verifier as BbsVerifier, HashElem,
-    ProofChallenge, SignatureMessage, SignatureProof,
+    keys::DeterministicPublicKey,
+    prelude::PublicKey,
+    verifier::Verifier as BbsVerifier,
+    HashElem,
+    ProofChallenge,
+    SignatureMessage,
+    SignatureProof,
 };
 use std::{collections::HashMap, error::Error, panic};
 
@@ -220,9 +228,12 @@ mod tests {
     use utilities::test_data::{
         accounts::local::{SIGNER_1_ADDRESS, SIGNER_1_DID, SIGNER_1_PRIVATE_KEY, VERIFIER_DID},
         bbs_coherent_context_test_data::{
-            NQUADS, PROOF_PRESENTATION, PROOF_PRESENTATION_INVALID_SIGNATURE_AND_WITHOUT_JWS,
+            NQUADS,
+            PROOF_PRESENTATION,
+            PROOF_PRESENTATION_INVALID_SIGNATURE_AND_WITHOUT_JWS,
             PROOF_REQUEST_SCHEMA_FIVE_PROPERTIES,
-            PROOF_REQUEST_SCHEMA_FIVE_PROPERTIES_WITHOUT_VERIFIER, PUB_KEY,
+            PROOF_REQUEST_SCHEMA_FIVE_PROPERTIES_WITHOUT_VERIFIER,
+            PUB_KEY,
             REVOCATION_LIST_CREDENTIAL,
         },
         vc_zkp::{EXAMPLE_CREDENTIAL_SCHEMA, EXAMPLE_CREDENTIAL_SCHEMA_FIVE_PROPERTIES},

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -17,9 +17,18 @@
 use crate::{
     application::{
         datatypes::{
-            BbsCredential, BbsCredentialOffer, BbsCredentialRequest, BbsProofRequest,
-            BbsProofVerification, CredentialProposal, CredentialSchema, CredentialSubject,
-            ProofPresentation, RevocationListCredential, SchemaProperty, UnfinishedBbsCredential,
+            BbsCredential,
+            BbsCredentialOffer,
+            BbsCredentialRequest,
+            BbsProofRequest,
+            BbsProofVerification,
+            CredentialProposal,
+            CredentialSchema,
+            CredentialSubject,
+            ProofPresentation,
+            RevocationListCredential,
+            SchemaProperty,
+            UnfinishedBbsCredential,
             UnsignedBbsCredential,
         },
         issuer::Issuer,
@@ -32,7 +41,8 @@ use crate::{
 use async_trait::async_trait;
 use bbs::{
     keys::{DeterministicPublicKey, SecretKey},
-    SignatureBlinding, SignatureMessage,
+    SignatureBlinding,
+    SignatureMessage,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, error::Error};

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -17,18 +17,9 @@
 use crate::{
     application::{
         datatypes::{
-            BbsCredential,
-            BbsCredentialOffer,
-            BbsCredentialRequest,
-            BbsProofRequest,
-            BbsProofVerification,
-            CredentialProposal,
-            CredentialSchema,
-            CredentialSubject,
-            ProofPresentation,
-            RevocationListCredential,
-            SchemaProperty,
-            UnfinishedBbsCredential,
+            BbsCredential, BbsCredentialOffer, BbsCredentialRequest, BbsProofRequest,
+            BbsProofVerification, CredentialProposal, CredentialSchema, CredentialSubject,
+            ProofPresentation, RevocationListCredential, SchemaProperty, UnfinishedBbsCredential,
             UnsignedBbsCredential,
         },
         issuer::Issuer,
@@ -41,8 +32,7 @@ use crate::{
 use async_trait::async_trait;
 use bbs::{
     keys::{DeterministicPublicKey, SecretKey},
-    SignatureBlinding,
-    SignatureMessage,
+    SignatureBlinding, SignatureMessage,
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, error::Error};
@@ -199,7 +189,7 @@ pub struct RequestCredentialPayload {
 #[serde(rename_all = "camelCase")]
 pub struct RequestProofPayload {
     /// DID of the verifier
-    pub verifier_did: String,
+    pub verifier_did: Option<String>,
     /// List of schema IDs to request
     pub schemas: Vec<String>,
     /// Attributes to reveal per schema ID

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -19,11 +19,23 @@ use serde_json::Value;
 use std::{collections::HashMap, env, error::Error};
 use utilities::test_data::{
     accounts::local::{
-        HOLDER_DID, ISSUER_DID, ISSUER_PRIVATE_KEY, ISSUER_PUBLIC_KEY_DID, SIGNER_1_ADDRESS,
-        SIGNER_1_DID, SIGNER_1_PRIVATE_KEY, SIGNER_2_DID, SIGNER_2_PRIVATE_KEY, VERIFIER_DID,
+        HOLDER_DID,
+        ISSUER_DID,
+        ISSUER_PRIVATE_KEY,
+        ISSUER_PUBLIC_KEY_DID,
+        SIGNER_1_ADDRESS,
+        SIGNER_1_DID,
+        SIGNER_1_PRIVATE_KEY,
+        SIGNER_2_DID,
+        SIGNER_2_PRIVATE_KEY,
+        VERIFIER_DID,
     },
     bbs_coherent_context_test_data::{
-        MASTER_SECRET, PUB_KEY, SECRET_KEY, SUBJECT_DID, UNSIGNED_CREDENTIAL,
+        MASTER_SECRET,
+        PUB_KEY,
+        SECRET_KEY,
+        SUBJECT_DID,
+        UNSIGNED_CREDENTIAL,
     },
     did::EXAMPLE_DID_DOCUMENT_2,
     environment::DEFAULT_VADE_EVAN_SUBSTRATE_IP,
@@ -33,7 +45,8 @@ use vade::Vade;
 use vade_evan_bbs::*;
 use vade_evan_substrate::{
     signing::{LocalSigner, Signer},
-    ResolverConfig, VadeEvanSubstrate,
+    ResolverConfig,
+    VadeEvanSubstrate,
 };
 
 const EVAN_METHOD: &str = "did:evan";

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -19,23 +19,11 @@ use serde_json::Value;
 use std::{collections::HashMap, env, error::Error};
 use utilities::test_data::{
     accounts::local::{
-        HOLDER_DID,
-        ISSUER_DID,
-        ISSUER_PRIVATE_KEY,
-        ISSUER_PUBLIC_KEY_DID,
-        SIGNER_1_ADDRESS,
-        SIGNER_1_DID,
-        SIGNER_1_PRIVATE_KEY,
-        SIGNER_2_DID,
-        SIGNER_2_PRIVATE_KEY,
-        VERIFIER_DID,
+        HOLDER_DID, ISSUER_DID, ISSUER_PRIVATE_KEY, ISSUER_PUBLIC_KEY_DID, SIGNER_1_ADDRESS,
+        SIGNER_1_DID, SIGNER_1_PRIVATE_KEY, SIGNER_2_DID, SIGNER_2_PRIVATE_KEY, VERIFIER_DID,
     },
     bbs_coherent_context_test_data::{
-        MASTER_SECRET,
-        PUB_KEY,
-        SECRET_KEY,
-        SUBJECT_DID,
-        UNSIGNED_CREDENTIAL,
+        MASTER_SECRET, PUB_KEY, SECRET_KEY, SUBJECT_DID, UNSIGNED_CREDENTIAL,
     },
     did::EXAMPLE_DID_DOCUMENT_2,
     environment::DEFAULT_VADE_EVAN_SUBSTRATE_IP,
@@ -45,8 +33,7 @@ use vade::Vade;
 use vade_evan_bbs::*;
 use vade_evan_substrate::{
     signing::{LocalSigner, Signer},
-    ResolverConfig,
-    VadeEvanSubstrate,
+    ResolverConfig, VadeEvanSubstrate,
 };
 
 const EVAN_METHOD: &str = "did:evan";
@@ -269,7 +256,7 @@ async fn create_proof_request(vade: &mut Vade) -> Result<BbsProofRequest, Box<dy
     let mut reveal_attributes = HashMap::new();
     reveal_attributes.insert(SCHEMA_DID.clone().to_string(), vec![1]);
     let proof_request_payload = RequestProofPayload {
-        verifier_did: VERIFIER_DID.to_string(),
+        verifier_did: Some(VERIFIER_DID.to_string()),
         schemas: vec![SCHEMA_DID.to_string()],
         reveal_attributes,
     };

--- a/utilities/src/test_data.rs
+++ b/utilities/src/test_data.rs
@@ -470,6 +470,20 @@ pub mod bbs_coherent_context_test_data {
         ]
      }"###;
 
+    pub const PROOF_REQUEST_SCHEMA_FIVE_PROPERTIES_WITHOUT_VERIFIER: &str = r###"{
+        "createdAt":"2021-04-13T12:53:19.000Z",
+        "nonce":"XWgrfaNTKs1owMRpmKNj8+CuRZJBC5BRCIErRv+DPUs=",
+        "type": "BBS",
+        "subProofRequests":[
+           {
+              "schema":"did:evan:zkp:0xd641c26161e769cef4b41760211972b274a8f37f135a34083e4e48b3f1035eda",
+              "revealedAttributes":[
+                 1
+              ]
+           }
+        ]
+     }"###;
+
     pub const PROOF_PRESENTATION: &str = r###"
     {
         "@context":[


### PR DESCRIPTION
This PR adjust the "proof request" input parameters, that the "verifierDid" can now be optional. The change allows then to generate proof requests without a specific verifier at all