### PR TITLE
Implement correct handling for required reveal statements in vade

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,8 @@ jobs:
         run: cargo test --no-fail-fast ${{ matrix.features.value }}
       - name: Switch to nightly for udeps
         run: rustup toolchain install nightly
+      - name: Update cargo
+        run: cargo update
       - name: Install cargo udeps
         run: cargo install cargo-udeps --locked
       - name: Run cargo udeps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2399,6 +2399,7 @@ dependencies = [
 [[package]]
 name = "vade-signer"
 version = "0.0.1"
+source = "git+https://github.com/evannetwork/vade-signer.git?branch=develop#c8636eef53ca71637c534a9098bad21f48852810"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -9,6 +9,7 @@
 - adjust `credential_status` to be optional property in Credential types
 - adjust `revocation_list` param in `VerifyProofPayload` to be optional
 - adjust types, tests and functions to remove `credential_subject.id` from credentials
+- implement handling for `required_revealed_statements` in presention creation and verification
 
 ### Fixes
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -9,7 +9,7 @@
 - adjust `credential_status` to be optional property in Credential types
 - adjust `revocation_list` param in `VerifyProofPayload` to be optional
 - adjust types, tests and functions to remove `credential_subject.id` from credentials
-- implement handling for `required_revealed_statements` in presentaion creation and verification
+- implement handling for `required_revealed_statements` in presentation creation and verification
 
 ### Fixes
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -9,7 +9,7 @@
 - adjust `credential_status` to be optional property in Credential types
 - adjust `revocation_list` param in `VerifyProofPayload` to be optional
 - adjust types, tests and functions to remove `credential_subject.id` from credentials
-- implement handling for `required_revealed_statements` in presention creation and verification
+- implement handling for `required_revealed_statements` in presentaion creation and verification
 
 ### Fixes
 

--- a/src/application/datatypes.rs
+++ b/src/application/datatypes.rs
@@ -423,6 +423,7 @@ impl BbsPresentation {
             proof: BbsPresentationProof {
                 created: cred.proof.created,
                 proof_purpose: cred.proof.proof_purpose,
+                required_reveal_statements: cred.proof.required_reveal_statements,
                 proof: base64::encode(proof.to_bytes_compressed_form()),
                 credential_message_count: cred.proof.credential_message_count,
                 r#type: PROOF_SIGNATURE_TYPE.to_owned(),
@@ -442,6 +443,7 @@ pub struct BbsPresentationProof {
     pub proof_purpose: String,
     pub credential_message_count: usize,
     pub verification_method: String,
+    pub required_reveal_statements: Vec<u32>,
     pub nonce: String,
     pub proof: String,
 }
@@ -564,7 +566,7 @@ pub struct LdProofVcDetailOptions {
 #[derive(Serialize, Deserialize, Clone)]
 pub struct LdProofVcDetail {
     pub credential: DraftBbsCredential,
-    pub options: LdProofVcDetailOptions, 
+    pub options: LdProofVcDetailOptions,
 }
 
 impl LdProofVcDetail {

--- a/src/application/datatypes.rs
+++ b/src/application/datatypes.rs
@@ -571,12 +571,13 @@ pub struct LdProofVcDetailOptions {
     pub created: String,
     pub proof_type: LdProofVcDetailOptionsType,
     pub credential_status: LdProofVcDetailOptionsCredentialStatus,
+    pub required_reveal_statements: Vec<u32>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 pub struct LdProofVcDetail {
     pub credential: DraftBbsCredential,
-    pub options: LdProofVcDetailOptions,
+    pub options: LdProofVcDetailOptions, 
 }
 
 impl LdProofVcDetail {

--- a/src/application/issuer.rs
+++ b/src/application/issuer.rs
@@ -37,7 +37,7 @@ use crate::{
             DEFAULT_REVOCATION_CONTEXTS,
         },
         utils::{
-            check_for_requird_reveal_index0,
+            check_for_required_reveal_index0,
             decode_base64,
             decode_base64_config,
             generate_uuid,
@@ -146,7 +146,7 @@ impl Issuer {
     ) -> Result<BbsCredentialOffer, Box<dyn Error>> {
         let nonce = base64::encode(BbsIssuer::generate_signing_nonce().to_bytes_compressed_form());
 
-        check_for_requird_reveal_index0(required_reveal_statements)?;
+        check_for_required_reveal_index0(required_reveal_statements)?;
 
         Ok(BbsCredentialOffer {
             ld_proof_vc_detail: LdProofVcDetail {
@@ -256,7 +256,7 @@ impl Issuer {
         revocation_list_id: Option<&str>,
         valid_until: Option<String>,
     ) -> Result<UnfinishedBbsCredential, Box<dyn Error>> {
-        check_for_requird_reveal_index0(
+        check_for_required_reveal_index0(
             &credential_offer
                 .ld_proof_vc_detail
                 .options

--- a/src/application/issuer.rs
+++ b/src/application/issuer.rs
@@ -36,7 +36,13 @@ use crate::{
             DEFAULT_CREDENTIAL_CONTEXTS,
             DEFAULT_REVOCATION_CONTEXTS,
         },
-        utils::{decode_base64, decode_base64_config, generate_uuid, get_now_as_iso_string},
+        utils::{
+            check_for_requird_reveal_index0,
+            decode_base64,
+            decode_base64_config,
+            generate_uuid,
+            get_now_as_iso_string,
+        },
     },
     crypto::{crypto_issuer::CryptoIssuer, crypto_utils::create_assertion_proof},
     DraftBbsCredential,
@@ -139,6 +145,8 @@ impl Issuer {
         credential_status_type: &LdProofVcDetailOptionsCredentialStatusType,
     ) -> Result<BbsCredentialOffer, Box<dyn Error>> {
         let nonce = base64::encode(BbsIssuer::generate_signing_nonce().to_bytes_compressed_form());
+
+        check_for_requird_reveal_index0(required_reveal_statements)?;
 
         Ok(BbsCredentialOffer {
             ld_proof_vc_detail: LdProofVcDetail {
@@ -248,6 +256,13 @@ impl Issuer {
         revocation_list_id: Option<&str>,
         valid_until: Option<String>,
     ) -> Result<UnfinishedBbsCredential, Box<dyn Error>> {
+        check_for_requird_reveal_index0(
+            &credential_offer
+                .ld_proof_vc_detail
+                .options
+                .required_reveal_statements,
+        )?;
+
         let mut credential_status: Option<CredentialStatus> = None;
         if revocation_list_id.is_some() || revocation_list_did.is_some() {
             let revocation_list_id =

--- a/src/application/issuer.rs
+++ b/src/application/issuer.rs
@@ -198,7 +198,12 @@ impl Issuer {
             created: get_now_as_iso_string(),
             proof_purpose: CREDENTIAL_PROOF_PURPOSE.to_owned(),
             verification_method: issuer_public_key_id.to_owned(),
-            required_reveal_statements: credential_request.credential_offer.ld_proof_vc_detail.options.required_reveal_statements.to_owned(),
+            required_reveal_statements: credential_request
+                .credential_offer
+                .ld_proof_vc_detail
+                .options
+                .required_reveal_statements
+                .to_owned(),
             credential_message_count: nquads.len() + ADDITIONAL_HIDDEN_MESSAGES_COUNT,
             blind_signature: base64::encode(blind_signature.to_bytes_compressed_form()),
         };
@@ -606,6 +611,7 @@ mod tests {
 
         let offer = Issuer::offer_credential(
             &draft,
+            &vec![1],
             &LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
         )?;
 
@@ -625,6 +631,7 @@ mod tests {
         });
         let mut offer = Issuer::offer_credential(
             &draft,
+            &vec![1],
             &LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
         )?;
         let key_id = format!("{}#key-1", ISSUER_DID);
@@ -637,15 +644,8 @@ mod tests {
             revocation_list_credential: EXAMPLE_REVOCATION_LIST_DID.to_string(),
         };
 
-        let result = Issuer::sign_nquads(
-            &credential_request,
-            Some(status),
-            &key_id,
-            &dpk,
-            &sk,
-            vec![1],
-        )
-        .await;
+        let result =
+            Issuer::sign_nquads(&credential_request, Some(status), &key_id, &dpk, &sk).await;
         match result {
             Ok(cred) => {
                 assert_credential(
@@ -677,6 +677,7 @@ mod tests {
         });
         let mut offer = Issuer::offer_credential(
             &draft,
+            &vec![1],
             &LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
         )?;
         let key_id = format!("{}#key-1", ISSUER_DID);
@@ -689,15 +690,8 @@ mod tests {
             revocation_list_credential: EXAMPLE_REVOCATION_LIST_DID.to_string(),
         };
 
-        let result = Issuer::sign_nquads(
-            &credential_request,
-            Some(status),
-            &key_id,
-            &dpk,
-            &sk,
-            vec![1],
-        )
-        .await;
+        let result =
+            Issuer::sign_nquads(&credential_request, Some(status), &key_id, &dpk, &sk).await;
 
         match result {
             Ok(cred) => {
@@ -730,6 +724,7 @@ mod tests {
         });
         let mut offer = Issuer::offer_credential(
             &draft,
+            &vec![1],
             &LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
         )?;
         let key_id = format!("{}#key-1", ISSUER_DID);
@@ -742,16 +737,7 @@ mod tests {
             revocation_list_credential: EXAMPLE_REVOCATION_LIST_DID.to_string(),
         };
 
-        match Issuer::sign_nquads(
-            &credential_request,
-            Some(status),
-            &key_id,
-            &dpk,
-            &sk,
-            vec![1],
-        )
-        .await
-        {
+        match Issuer::sign_nquads(&credential_request, Some(status), &key_id, &dpk, &sk).await {
             Ok(cred) => assert_credential_proof(cred, &key_id, [1].to_vec()),
             Err(e) => assert!(false, "Received error when issuing credential: {}", e),
         }
@@ -771,6 +757,7 @@ mod tests {
         });
         let mut offer = Issuer::offer_credential(
             &draft,
+            &vec![1],
             &LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
         )?;
         let key_id = format!("{}#key-1", ISSUER_DID);

--- a/src/application/issuer.rs
+++ b/src/application/issuer.rs
@@ -133,6 +133,7 @@ impl Issuer {
     /// * `BbsCredentialOffer` - The message to be sent to the prover.
     pub fn offer_credential(
         credential: &DraftBbsCredential,
+        required_reveal_statements: Vec<u32>,
     ) -> Result<BbsCredentialOffer, Box<dyn Error>> {
         let nonce = base64::encode(BbsIssuer::generate_signing_nonce().to_bytes_compressed_form());
 
@@ -146,6 +147,7 @@ impl Issuer {
                         r#type:
                             LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
                     },
+                    required_reveal_statements,
                 },
             },
             nonce,
@@ -585,7 +587,7 @@ mod tests {
     fn can_offer_credential() -> Result<(), Box<dyn Error>> {
         let proposal: CredentialProposal = serde_json::from_str(&EXAMPLE_CREDENTIAL_PROPOSAL)?;
         let schema: CredentialSchema = serde_json::from_str(&SCHEMA)?;
-        let mut draft = schema.to_draft_credential(CredentialDraftOptions {
+        let mut draft: DraftBbsCredential = schema.to_draft_credential(CredentialDraftOptions {
             issuer_did: ISSUER_DID.to_string(),
             id: None,
             issuance_date: None,

--- a/src/application/issuer.rs
+++ b/src/application/issuer.rs
@@ -135,7 +135,7 @@ impl Issuer {
     /// # Arguments
     /// * `credential` - draft credential to be offered
     /// * `required_reveal_statements` - required indices to be revealed
-    /// * `credential_status_type` - draft credential to be offered
+    /// * `credential_status_type` - type of credential status
     ///
     /// # Returns
     /// * `BbsCredentialOffer` - The message to be sent to the prover.

--- a/src/application/prover.rs
+++ b/src/application/prover.rs
@@ -28,7 +28,11 @@ use super::{
         UnfinishedProofPresentation,
         DEFAULT_CREDENTIAL_CONTEXTS,
     },
-    utils::{concate_required_and_reveal_statements, get_nonce_from_string},
+    utils::{
+        check_for_requird_reveal_index0,
+        concate_required_and_reveal_statements,
+        get_nonce_from_string,
+    },
 };
 use crate::{
     application::utils::generate_uuid,
@@ -156,6 +160,7 @@ impl Prover {
         issuer_public_key: &DeterministicPublicKey,
         blinding: &SignatureBlinding,
     ) -> Result<BbsCredential, Box<dyn Error>> {
+        check_for_requird_reveal_index0(&unfinished_credential.proof.required_reveal_statements)?;
         let final_signature = CryptoProver::finish_credential_signature(
             nquads.clone(),
             master_secret,
@@ -211,6 +216,7 @@ impl Prover {
                 .clone();
 
             let required_reveal_statements = credential.proof.required_reveal_statements.to_owned();
+            check_for_requird_reveal_index0(&required_reveal_statements)?;
             let revealed_statements = sub_proof_request.revealed_attributes.to_owned();
             let all_revealed_statements = concate_required_and_reveal_statements(
                 required_reveal_statements,

--- a/src/application/prover.rs
+++ b/src/application/prover.rs
@@ -29,8 +29,8 @@ use super::{
         DEFAULT_CREDENTIAL_CONTEXTS,
     },
     utils::{
-        check_for_requird_reveal_index0,
-        concate_required_and_reveal_statements,
+        check_for_required_reveal_index0,
+        concat_required_and_reveal_statements,
         get_nonce_from_string,
     },
 };
@@ -160,7 +160,7 @@ impl Prover {
         issuer_public_key: &DeterministicPublicKey,
         blinding: &SignatureBlinding,
     ) -> Result<BbsCredential, Box<dyn Error>> {
-        check_for_requird_reveal_index0(&unfinished_credential.proof.required_reveal_statements)?;
+        check_for_required_reveal_index0(&unfinished_credential.proof.required_reveal_statements)?;
         let final_signature = CryptoProver::finish_credential_signature(
             nquads.clone(),
             master_secret,
@@ -216,9 +216,9 @@ impl Prover {
                 .clone();
 
             let required_reveal_statements = credential.proof.required_reveal_statements.to_owned();
-            check_for_requird_reveal_index0(&required_reveal_statements)?;
+            check_for_required_reveal_index0(&required_reveal_statements)?;
             let revealed_statements = sub_proof_request.revealed_attributes.to_owned();
-            let all_revealed_statements = concate_required_and_reveal_statements(
+            let all_revealed_statements = concat_required_and_reveal_statements(
                 required_reveal_statements,
                 revealed_statements,
             )?;

--- a/src/application/prover.rs
+++ b/src/application/prover.rs
@@ -215,9 +215,9 @@ impl Prover {
                 ))?
                 .clone();
 
-            let required_reveal_statements = credential.proof.required_reveal_statements.to_owned();
+            let required_reveal_statements = &credential.proof.required_reveal_statements;
             check_for_required_reveal_index0(&required_reveal_statements)?;
-            let revealed_statements = sub_proof_request.revealed_attributes.to_owned();
+            let revealed_statements = &sub_proof_request.revealed_attributes;
             let all_revealed_statements = concat_required_and_reveal_statements(
                 required_reveal_statements,
                 revealed_statements,

--- a/src/application/utils.rs
+++ b/src/application/utils.rs
@@ -192,3 +192,26 @@ pub async fn get_nquads_schema_map(
 
     Ok(nquads_schema_map)
 }
+
+pub fn concate_required_and_reveal_statements(
+    required_reveal_statements: Vec<u32>,
+    revealed_statements: Vec<usize>,
+) -> Result<Vec<usize>, Box<dyn Error>> {
+    let mut all_revealed_statements: Vec<usize> = vec![];
+    for required_index in required_reveal_statements {
+        if required_index == 0 {
+            return Err(Box::from(
+                "Invalid reveal index!, index 0 can't be revealed",
+            ));
+        }
+        all_revealed_statements.push(required_index as usize);
+    }
+
+    for revealed_index in revealed_statements {
+        if !all_revealed_statements.contains(&revealed_index) {
+            all_revealed_statements.push(revealed_index);
+        }
+    }
+    all_revealed_statements.sort();
+    Ok(all_revealed_statements)
+}

--- a/src/application/utils.rs
+++ b/src/application/utils.rs
@@ -215,3 +215,18 @@ pub fn concate_required_and_reveal_statements(
     all_revealed_statements.sort();
     Ok(all_revealed_statements)
 }
+
+pub fn check_for_requird_reveal_index0(
+    required_revealed_statements: &Vec<u32>,
+) -> Result<(), Box<dyn Error>> {
+    match required_revealed_statements
+        .into_iter()
+        .find(|index| **index == 0)
+        .is_some()
+    {
+        true => Err(Box::from(
+            "Invalid required_revealed_index! index 0 can't be revealed".to_owned(),
+        )),
+        false => Ok(()),
+    }
+}

--- a/src/application/utils.rs
+++ b/src/application/utils.rs
@@ -209,9 +209,7 @@ pub fn concate_required_and_reveal_statements(
     let mut all_revealed_statements: Vec<usize> = vec![];
     for required_index in required_reveal_statements {
         if required_index == 0 {
-            return Err(Box::from(
-                "Invalid reveal index, index 0 can't be revealed",
-            ));
+            return Err(Box::from("Invalid reveal index, index 0 can't be revealed"));
         }
         all_revealed_statements.push(required_index as usize);
     }

--- a/src/application/utils.rs
+++ b/src/application/utils.rs
@@ -203,18 +203,18 @@ pub async fn get_nquads_schema_map(
 /// # Returns
 /// * `Vec<usize>` - A vector containing all the indices to be revealed by presentation
 pub fn concat_required_and_reveal_statements(
-    required_reveal_statements: Vec<u32>,
-    revealed_statements: Vec<usize>,
+    required_reveal_statements: &Vec<u32>,
+    revealed_statements: &Vec<usize>,
 ) -> Result<Vec<usize>, Box<dyn Error>> {
     let mut all_revealed_statements: Vec<usize> = vec![];
-    check_for_required_reveal_index0(&required_reveal_statements)?;
+    check_for_required_reveal_index0(required_reveal_statements)?;
     for required_index in required_reveal_statements {
-        all_revealed_statements.push(required_index as usize);
+        all_revealed_statements.push(*required_index as usize);
     }
 
     for revealed_index in revealed_statements {
         if !all_revealed_statements.contains(&revealed_index) {
-            all_revealed_statements.push(revealed_index);
+            all_revealed_statements.push(*revealed_index);
         }
     }
     all_revealed_statements.sort();

--- a/src/application/utils.rs
+++ b/src/application/utils.rs
@@ -225,7 +225,7 @@ pub fn check_for_requird_reveal_index0(
         .is_some()
     {
         true => Err(Box::from(
-            "Invalid required_revealed_index! index 0 can't be revealed".to_owned(),
+            "Invalid required_revealed_index, index 0 can't be revealed".to_owned(),
         )),
         false => Ok(()),
     }

--- a/src/application/utils.rs
+++ b/src/application/utils.rs
@@ -193,6 +193,15 @@ pub async fn get_nquads_schema_map(
     Ok(nquads_schema_map)
 }
 
+/// Concatenates the revealed statements vector from proof request and required revealed statements vector
+/// from credential proof to get all the indices need to be revealed in the presentation.
+///
+/// # Arguments
+/// * `required_revealed_statements` - vec of required revealed indices
+/// * `revealed_statements` - vec of requested revealed indices
+///
+/// # Returns
+/// * `Vec<usize>` - A vector containing all the indices to be revealed by presentation
 pub fn concate_required_and_reveal_statements(
     required_reveal_statements: Vec<u32>,
     revealed_statements: Vec<usize>,
@@ -216,6 +225,11 @@ pub fn concate_required_and_reveal_statements(
     Ok(all_revealed_statements)
 }
 
+/// Checks if the required revealed statements are containing 0 index (master_secret)
+/// Throws error if it contains the index 0 as required reveal index.
+///
+/// # Arguments
+/// * `required_revealed_statements` - vec of required revealed indices
 pub fn check_for_requird_reveal_index0(
     required_revealed_statements: &Vec<u32>,
 ) -> Result<(), Box<dyn Error>> {

--- a/src/application/utils.rs
+++ b/src/application/utils.rs
@@ -202,15 +202,13 @@ pub async fn get_nquads_schema_map(
 ///
 /// # Returns
 /// * `Vec<usize>` - A vector containing all the indices to be revealed by presentation
-pub fn concate_required_and_reveal_statements(
+pub fn concat_required_and_reveal_statements(
     required_reveal_statements: Vec<u32>,
     revealed_statements: Vec<usize>,
 ) -> Result<Vec<usize>, Box<dyn Error>> {
     let mut all_revealed_statements: Vec<usize> = vec![];
+    check_for_required_reveal_index0(&required_reveal_statements)?;
     for required_index in required_reveal_statements {
-        if required_index == 0 {
-            return Err(Box::from("Invalid reveal index, index 0 can't be revealed"));
-        }
         all_revealed_statements.push(required_index as usize);
     }
 
@@ -228,7 +226,7 @@ pub fn concate_required_and_reveal_statements(
 ///
 /// # Arguments
 /// * `required_revealed_statements` - vec of required revealed indices
-pub fn check_for_requird_reveal_index0(
+pub fn check_for_required_reveal_index0(
     required_revealed_statements: &Vec<u32>,
 ) -> Result<(), Box<dyn Error>> {
     match required_revealed_statements
@@ -237,7 +235,7 @@ pub fn check_for_requird_reveal_index0(
         .is_some()
     {
         true => Err(Box::from(
-            "Invalid required_revealed_index, index 0 can't be revealed".to_owned(),
+            "Invalid required reveal statement! Index 0 can't be revealed".to_owned(),
         )),
         false => Ok(()),
     }

--- a/src/application/utils.rs
+++ b/src/application/utils.rs
@@ -201,7 +201,7 @@ pub fn concate_required_and_reveal_statements(
     for required_index in required_reveal_statements {
         if required_index == 0 {
             return Err(Box::from(
-                "Invalid reveal index!, index 0 can't be revealed",
+                "Invalid reveal index, index 0 can't be revealed",
             ));
         }
         all_revealed_statements.push(required_index as usize);

--- a/src/application/verifier.rs
+++ b/src/application/verifier.rs
@@ -148,7 +148,6 @@ impl Verifier {
         if presentation.verifiable_credential.len() == 0 {
             return Err(Box::from("Invalid presentation: No credentials provided"));
         }
-
         check_assertion_proof(&serde_json::to_string(&presentation)?, signer_address)?;
 
         let challenge =

--- a/src/application/verifier.rs
+++ b/src/application/verifier.rs
@@ -173,17 +173,6 @@ impl Verifier {
             let proof = panic::catch_unwind(|| SignatureProof::from(proof_bytes))
                 .map_err(|_| "Error parsing signature")?;
 
-            match verify_presentation(&proof, &key, &challenge, &cred) {
-                Err(e) => {
-                    return Ok(BbsProofVerification {
-                        presented_proof: presentation.id.to_string(),
-                        status: "rejected".to_string(),
-                        reason: Some(e.to_string()),
-                    })
-                }
-                Ok(()) => (),
-            }
-
             match verify_revealed_messages(
                 nquads_to_schema_map
                     .get(&cred.credential_schema.id)
@@ -193,6 +182,16 @@ impl Verifier {
                     ))?,
                 &proof,
             ) {
+                Err(e) => {
+                    return Ok(BbsProofVerification {
+                        presented_proof: presentation.id.to_string(),
+                        status: "rejected".to_string(),
+                        reason: Some(e.to_string()),
+                    })
+                }
+                Ok(()) => (),
+            }
+            match verify_presentation(&proof, &key, &challenge, &cred) {
                 Err(e) => {
                     return Ok(BbsProofVerification {
                         presented_proof: presentation.id.to_string(),

--- a/src/crypto/crypto_prover.rs
+++ b/src/crypto/crypto_prover.rs
@@ -17,7 +17,7 @@
 use crate::application::{
     datatypes::{BbsCredentialSignature, BbsSubProofRequest, UnfinishedBbsCredentialSignature},
     issuer::ADDITIONAL_HIDDEN_MESSAGES_COUNT,
-    utils::{concate_required_and_reveal_statements, decode_base64},
+    utils::{concat_required_and_reveal_statements, decode_base64},
 };
 use bbs::{
     keys::DeterministicPublicKey,
@@ -121,7 +121,7 @@ impl CryptoProver {
                 .map_err(|e| format!("could not create new proof request; {}", &e))?;
         let required_reveal_statements = credential_signature.required_reveal_statements.to_owned();
         let revealed_statements = sub_proof_request.revealed_attributes.to_owned();
-        let all_revealed_statements = concate_required_and_reveal_statements(
+        let all_revealed_statements = concat_required_and_reveal_statements(
             required_reveal_statements,
             revealed_statements,
         )?;

--- a/src/crypto/crypto_prover.rs
+++ b/src/crypto/crypto_prover.rs
@@ -121,10 +121,8 @@ impl CryptoProver {
                 .map_err(|e| format!("could not create new proof request; {}", &e))?;
         let required_reveal_statements = &credential_signature.required_reveal_statements;
         let revealed_statements = &sub_proof_request.revealed_attributes;
-        let all_revealed_statements = concat_required_and_reveal_statements(
-            required_reveal_statements,
-            revealed_statements,
-        )?;
+        let all_revealed_statements =
+            concat_required_and_reveal_statements(required_reveal_statements, revealed_statements)?;
 
         let indices: HashSet<&usize> = HashSet::from_iter(all_revealed_statements.iter());
 

--- a/src/crypto/crypto_prover.rs
+++ b/src/crypto/crypto_prover.rs
@@ -119,14 +119,14 @@ impl CryptoProver {
         let crypto_proof_request =
             BbsVerifier::new_proof_request(&sub_proof_request.revealed_attributes.as_slice(), &pk)
                 .map_err(|e| format!("could not create new proof request; {}", &e))?;
-        let required_reveal_statements = credential_signature.required_reveal_statements.to_owned();
-        let revealed_statements = sub_proof_request.revealed_attributes.to_owned();
+        let required_reveal_statements = &credential_signature.required_reveal_statements;
+        let revealed_statements = &sub_proof_request.revealed_attributes;
         let all_revealed_statements = concat_required_and_reveal_statements(
             required_reveal_statements,
             revealed_statements,
         )?;
 
-        let indices: HashSet<usize> = HashSet::from_iter(all_revealed_statements.iter().cloned());
+        let indices: HashSet<&usize> = HashSet::from_iter(all_revealed_statements.iter());
 
         let mut commitment_messages = Vec::new();
         let link_secret_blinding = ProofNonce::random();

--- a/src/crypto/crypto_prover.rs
+++ b/src/crypto/crypto_prover.rs
@@ -17,7 +17,7 @@
 use crate::application::{
     datatypes::{BbsCredentialSignature, BbsSubProofRequest, UnfinishedBbsCredentialSignature},
     issuer::ADDITIONAL_HIDDEN_MESSAGES_COUNT,
-    utils::decode_base64,
+    utils::{concate_required_and_reveal_statements, decode_base64},
 };
 use bbs::{
     keys::DeterministicPublicKey,
@@ -119,9 +119,14 @@ impl CryptoProver {
         let crypto_proof_request =
             BbsVerifier::new_proof_request(&sub_proof_request.revealed_attributes.as_slice(), &pk)
                 .map_err(|e| format!("could not create new proof request; {}", &e))?;
+        let required_reveal_statements = credential_signature.required_reveal_statements.to_owned();
+        let revealed_statements = sub_proof_request.revealed_attributes.to_owned();
+        let all_revealed_statements = concate_required_and_reveal_statements(
+            required_reveal_statements,
+            revealed_statements,
+        )?;
 
-        let indices: HashSet<usize> =
-            HashSet::from_iter(sub_proof_request.revealed_attributes.iter().cloned());
+        let indices: HashSet<usize> = HashSet::from_iter(all_revealed_statements.iter().cloned());
 
         let mut commitment_messages = Vec::new();
         let link_secret_blinding = ProofNonce::random();

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -35,7 +35,7 @@ use crate::{
         issuer::Issuer,
         prover::Prover,
         utils::{
-            concate_required_and_reveal_statements,
+            concat_required_and_reveal_statements,
             convert_to_nquads,
             decode_base64,
             generate_uuid,
@@ -783,7 +783,7 @@ impl VadePlugin for VadeEvanBbs {
                 })?;
             let required_reveal_statements = vc.proof.required_reveal_statements.to_owned();
             let revealed_statements = sub_request.revealed_attributes.to_owned();
-            let all_revealed_statements = concate_required_and_reveal_statements(
+            let all_revealed_statements = concat_required_and_reveal_statements(
                 required_reveal_statements,
                 revealed_statements,
             )?;

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -781,8 +781,8 @@ impl VadePlugin for VadeEvanBbs {
                         sub_request.schema
                     )
                 })?;
-            let required_reveal_statements = vc.proof.required_reveal_statements.to_owned();
-            let revealed_statements = sub_request.revealed_attributes.to_owned();
+            let required_reveal_statements = &vc.proof.required_reveal_statements;
+            let revealed_statements = &sub_request.revealed_attributes;
             let all_revealed_statements = concat_required_and_reveal_statements(
                 required_reveal_statements,
                 revealed_statements,

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -1022,7 +1022,7 @@ async fn workflow_can_not_offer_credenial_with_required_revealed_index_0(
         Err(e) => {
             assert!(e
                 .to_string()
-                .contains("Invalid required_revealed_index, index 0 can't be revealed"))
+                .contains("Invalid required reveal statement! Index 0 can't be revealed"))
         }
     }
 

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -163,7 +163,6 @@ async fn create_unfinished_credential(
         issuer_public_key_id: key_id.clone(),
         issuer_public_key: PUB_KEY.to_string(),
         issuer_secret_key: SECRET_KEY.to_string(),
-        required_indices: [1].to_vec(),
     };
     let issue_cred_json = serde_json::to_string(&issue_cred)?;
 
@@ -313,6 +312,7 @@ async fn workflow_can_create_credential_offer_with_proposal() -> Result<(), Box<
         }),
         credential_status_type:
             LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
+        required_reveal_statements: vec![1],
     };
 
     let offering = create_credential_offer(&mut vade, offer_payload).await?;
@@ -336,6 +336,7 @@ async fn workflow_can_create_credential_request() -> Result<(), Box<dyn Error>> 
         }),
         credential_status_type:
             LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
+        required_reveal_statements: vec![1],
     };
 
     let offer = create_credential_offer(&mut vade, offer_payload).await?;
@@ -371,6 +372,7 @@ async fn workflow_cannot_create_credential_request_with_missing_required_schema_
         }),
         credential_status_type:
             LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
+        required_reveal_statements: vec![1],
     };
 
     let mut offer = create_credential_offer(&mut vade, offer_payload).await?;
@@ -410,6 +412,7 @@ async fn workflow_cannot_create_credential_request_with_empty_values() -> Result
         }),
         credential_status_type:
             LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
+        required_reveal_statements: vec![1],
     };
 
     let mut offer = create_credential_offer(&mut vade, offer_payload).await?;
@@ -451,6 +454,7 @@ async fn workflow_can_create_unfinished_credential() -> Result<(), Box<dyn Error
         }),
         credential_status_type:
             LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
+        required_reveal_statements: vec![1],
     };
 
     let offer = create_credential_offer(&mut vade, offer_payload).await?;
@@ -492,6 +496,7 @@ async fn workflow_can_create_finished_credential() -> Result<(), Box<dyn Error>>
         draft_credential: credential_draft,
         credential_status_type:
             LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
+        required_reveal_statements: vec![1],
     };
 
     let offer = create_credential_offer(&mut vade, offer_payload).await?;
@@ -570,6 +575,7 @@ async fn workflow_can_create_finished_credential_without_credential_status(
     let offer_payload = OfferCredentialPayload {
         draft_credential: credential_draft,
         credential_status_type: LdProofVcDetailOptionsCredentialStatusType::None,
+        required_reveal_statements: vec![1],
     };
 
     let offer = create_credential_offer(&mut vade, offer_payload).await?;
@@ -630,6 +636,7 @@ async fn workflow_can_propose_request_issue_verify_a_credential() -> Result<(), 
         draft_credential: credential_draft,
         credential_status_type:
             LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
+        required_reveal_statements: vec![1],
     };
 
     let offer = create_credential_offer(&mut vade, offer_payload).await?;
@@ -710,6 +717,7 @@ async fn workflow_cannot_verify_revoked_credential() -> Result<(), Box<dyn Error
         draft_credential: credential_draft,
         credential_status_type:
             LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
+        required_reveal_statements: vec![1],
     };
 
     let offer = create_credential_offer(&mut vade, offer_payload).await?;

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -1022,7 +1022,7 @@ async fn workflow_can_not_offer_credenial_with_required_revealed_index_0(
         Err(e) => {
             assert!(e
                 .to_string()
-                .contains("Invalid required_revealed_index! index 0 can't be revealed"))
+                .contains("Invalid required_revealed_index, index 0 can't be revealed"))
         }
     }
 

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -901,6 +901,94 @@ async fn workflow_can_not_verify_presentation_mismatch_revealed_statements(
 }
 
 #[tokio::test]
+async fn workflow_can_not_verify_presentation_mismatch_required_revealed_statements(
+) -> Result<(), Box<dyn Error>> {
+    let mut vade = get_vade();
+
+    let revocation_list = create_revocation_list(&mut vade).await?;
+
+    // Create credential offering
+    let schema = CredentialSchema::from_str(SCHEMA)?;
+    let mut credential_draft = schema.to_draft_credential(CredentialDraftOptions {
+        issuer_did: ISSUER_DID.to_string(),
+        id: None,
+        issuance_date: None,
+        valid_until: None,
+    });
+    let mut credential_values = HashMap::new();
+    credential_values.insert("test_property_string3".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string1".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string2".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string4".to_owned(), "value".to_owned());
+    credential_draft.credential_subject.data = credential_values;
+    let offer_payload = OfferCredentialPayload {
+        draft_credential: credential_draft,
+        credential_status_type:
+            LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
+        required_reveal_statements: vec![1],
+    };
+
+    let offer = create_credential_offer(&mut vade, offer_payload).await?;
+    let (credential_request, signature_blinding_base64) =
+        create_credential_request(&mut vade, offer.clone()).await?;
+
+    let unfinished_credential = create_unfinished_credential(
+        &mut vade,
+        credential_request,
+        Some(revocation_list.id.clone()),
+        Some("0".to_string()),
+    )
+    .await?;
+    let finished_credential = create_finished_credential(
+        &mut vade,
+        unfinished_credential.clone(),
+        signature_blinding_base64.clone(),
+    )
+    .await?;
+    // create proof request
+    let mut proof_request = create_proof_request(&mut vade).await?;
+    proof_request.sub_proof_requests[0].revealed_attributes = vec![10, 11];
+
+    // create proof
+    let mut public_key_schema_map = HashMap::new();
+    public_key_schema_map.insert(SCHEMA_DID.to_string(), PUB_KEY.to_string());
+    let mut presentation = create_presentation(
+        &mut vade,
+        finished_credential.clone(),
+        proof_request.clone(),
+        public_key_schema_map.clone(),
+    )
+    .await?;
+
+    // change required_revealed_statements after presentation is created
+    presentation.verifiable_credential[0]
+        .proof
+        .required_reveal_statements = vec![15];
+    // verify proof
+    let verify_proof_payload = VerifyProofPayload {
+        presentation: presentation.clone(),
+        proof_request: proof_request.clone(),
+        keys_to_schema_map: public_key_schema_map,
+        signer_address: SIGNER_1_ADDRESS.to_string(),
+        revocation_list: Some(revocation_list.clone()),
+    };
+    let verify_proof_json = serde_json::to_string(&verify_proof_payload)?;
+    let result = vade
+        .vc_zkp_verify_proof(EVAN_METHOD, TYPE_OPTIONS, &verify_proof_json)
+        .await;
+
+    match result {
+        Ok(_) => assert!(false, "Presentation verification should fail"),
+        Err(e) => assert!(e
+            .to_string()
+            .contains("recovered VC document and given VC document do not match")),
+    };
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn workflow_can_not_offer_credenial_with_required_revealed_index_0(
 ) -> Result<(), Box<dyn Error>> {
     let mut vade = get_vade();
@@ -929,7 +1017,6 @@ async fn workflow_can_not_offer_credenial_with_required_revealed_index_0(
 
     let result: Result<BbsCredentialOffer, Box<dyn Error>> =
         create_credential_offer(&mut vade, offer_payload).await;
-    assert!(result.is_err());
     match result {
         Ok(_) => assert!(false, "Credential offer creation should fail"),
         Err(e) => {

--- a/typings/application/datatypes.d.ts
+++ b/typings/application/datatypes.d.ts
@@ -240,6 +240,7 @@ export interface BbsPresentationProof {
   proofPurpose: string;
   credentialMessageCount: number;
   verificationMethod: string;
+  requiredRevealStatements: number[];
   nonce: string;
   proof: string;
 }
@@ -304,6 +305,7 @@ export interface LdProofVcDetailOptions {
     created: string;
     proofType: LdProofVcDetailOptionsType;
     credentialStatus: LdProofVcDetailOptionsCredentialStatus;
+    requiredRevealStatements: number[];
 }
 
 export interface LdProofVcDetail {

--- a/typings/vade_evan_bbs.d.ts
+++ b/typings/vade_evan_bbs.d.ts
@@ -81,7 +81,7 @@ export interface OfferCredentialPayload {
   /** credential draft, outlining structure of future credential (without proof and status) */
   draftCredential: DraftBbsCredential;
   credentialStatusType: LdProofVcDetailOptionsCredentialStatusType,
-
+  requiredRevealStatements: number[];
 }
 
 /** API payload for creating a zero-knowledge proof out of a BBS+ signature. */

--- a/utilities/src/test_data.rs
+++ b/utilities/src/test_data.rs
@@ -364,121 +364,125 @@ pub mod bbs_coherent_context_test_data {
      }"###;
 
     pub const PROOF_PRESENTATION: &str = r###"{
-      "@context":[
-         "https://www.w3.org/2018/credentials/v1",
-         "https://schema.org/",
-         "https://w3id.org/vc-revocation-list-2020/v1"
-      ],
-      "id":"5920976a-e591-476e-be19-82968545e9e9",
-      "type":[
-         "VerifiablePresentation"
-      ],
-      "verifiableCredential":[
-         {
-            "@context":[
-               "https://www.w3.org/2018/credentials/v1",
-               "https://schema.org/",
-               "https://w3id.org/vc-revocation-list-2020/v1"
-            ],
-            "id":"uuid:c2872087-3fe6-4aeb-932d-a528709b0f0a",
-            "type":[
-               "VerifiableCredential"
-            ],
-            "issuer":"did:evan:EiDmRkKsOaey8tPzc6RyQrYkMNjpqXXVTj9ggy0EbiXS4g",
-            "issuanceDate":"2023-05-02T12:56:07.000Z",
-            "credentialSubject":{
-               "data":{
-                  "test_property_string3":"value",
-                  "test_property_string1":"value",
-                  "test_property_string":"value",
-                  "test_property_string4":"value",
-                  "test_property_string2":"value"
-               }
-            },
-            "credentialSchema":{
-               "id":"did:evan:EiBmiHCHLMbGVn9hllRM5qQOsshvETToEALBAtFqP3PUIg",
-               "type":"EvanVCSchema"
-            },
-            "credentialStatus":{
-               "id":"did:evan:revocation123#0",
-               "type":"RevocationList2021Status",
-               "revocationListIndex":"0",
-               "revocationListCredential":"did:evan:revocation123"
-            },
-            "proof":{
-               "type":"BbsBlsSignatureProof2020",
-               "created":"2023-05-02T12:56:07.000Z",
-               "proofPurpose":"assertionMethod",
-               "credentialMessageCount":17,
-               "requiredRevealStatements":[1],
-               "verificationMethod":"did:evan:EiDmRkKsOaey8tPzc6RyQrYkMNjpqXXVTj9ggy0EbiXS4g#bbs-key-1",
-               "nonce":"Ren4koCh6lIDeeVODbesrd/nZj5rvf5Uj1orC+MyxKY=",
-               "proof":"AAADXLaKsJIrzhIoepOUbLoxiYkbVTV5lZFh4qZTVSpegJZjZxPX+tZ5RpRcJIXiJ7HmCo4OHOc5gLDNE8WynpIN+0wKMCm60+XIBc5vTLVoZZStfk8ICC6ernkvbQ64+VicVIMY54eDSE8VJV1J7PkwkdkKDExP47eeRydqQ85Uu7Fj9IQOH2LZPDxHs7QCWTxOyAAAAHSxTgvZ0wvfNaMkwpjGBpUOq5a6egscEj9iNUeWJC6tS7C8Y0SYogr04nFHCFWTzR4AAAACPcNTHZ7tCo3Ee+FwPyIVtuFi6I+t2B5DIHE6FC5aypFj0jpEkhgnbnxyouAZoXbJD12JMAy/yBx3bysu2/gMJ5BWWpj+uO8vm2rcRyaaxoePUy9bR5KmNkQzqFgmasjmZOelK4V+osfHujjcWQWiFgAAABFf9o85jgob5/x6171ivxwowxysBCFVoqnBR+N6JVlf2nEe3ykO2kFIvDNwyKgh0iXZGdhVaYTue6eJQ0QZzwQ6VMia51FfdiGXf4Hwtd14C/E0olhscpvFxJPNIbKftjEoggIg3eMXVMXDD/Ka29uzYJ3IbL+j3i/8KzyId1O/kjsWULxZ0gv19ylIw/S5n4jOc0RE1V5WYn/MflO3TXixX/5OrLWQ4fZoEmG8G8VtVnwCax4/zOMDHKiDb3hesa1w+wAXDrrf7iUHAIWWP/G0OU0aFbehLKmKjvUbTHyy/gwfYxcOHrihq9Lf8mSXazjgZOuHvSBYb+XdmwTioH+hKpXw7CwuaK296Okd9deyw5FJb2glRqshJb5trX3QV3pbK9GfBDL8FS3KMgZKM+GOg6X1TYOFC6W0w1pjb4dA8GNzNDcBrStSdUm0zUtso68kBabLHxIcxF7oms8tBW6qF/F6zQ9mQAFgE8Iw+q5cn4V9/YJFhq0vKICyl4IKdPdYyjmNeB86vmXi3XPg3FMI1Bt0SYgWOxdgwA47PSpdFl4ZwzlPCug7dv1MPP9QnqcSyAjiHKTkh4DT4KHWGZT2SGDRxi3pw1tfbep1Vd/VAGj7yRitiPR+hvVFRiYPizRyoY2frsWEe50E2AZz0WdGWSQEiFQ3KGmVlYHhei9KBmZ0NdTQjqU22/mjntBTZd6Tt10BVVJVdfzUtT3InwUfAAAAAgAAAApbW8IfIW09a9avCC6ldA6iaqjfsZj0JqD6wKVOZZoXBgAAAAsFnuYa41LQpFmhhhn4u2raXdWzPs1CJF+1sQhsXO0KIA=="
-            }
-         }
-      ],
-      "proof":{
-         "type":"EcdsaPublicKeySecp256k1",
-         "created":"2023-05-02T12:56:07.000Z",
-         "proofPurpose":"assertionMethod",
-         "verificationMethod":"did:evan:verifier#key-1",
-         "jws":"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOiIyMDIzLTA1LTAyVDEyOjU2OjA3LjAwMFoiLCJkb2MiOnsiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3NjaGVtYS5vcmcvIiwiaHR0cHM6Ly93M2lkLm9yZy92Yy1yZXZvY2F0aW9uLWxpc3QtMjAyMC92MSJdLCJpZCI6IjU5MjA5NzZhLWU1OTEtNDc2ZS1iZTE5LTgyOTY4NTQ1ZTllOSIsInR5cGUiOlsiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJdLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6W3siQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3NjaGVtYS5vcmcvIiwiaHR0cHM6Ly93M2lkLm9yZy92Yy1yZXZvY2F0aW9uLWxpc3QtMjAyMC92MSJdLCJpZCI6InV1aWQ6YzI4NzIwODctM2ZlNi00YWViLTkzMmQtYTUyODcwOWIwZjBhIiwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCJdLCJpc3N1ZXIiOiJkaWQ6ZXZhbjpFaURtUmtLc09hZXk4dFB6YzZSeVFyWWtNTmpwcVhYVlRqOWdneTBFYmlYUzRnIiwiaXNzdWFuY2VEYXRlIjoiMjAyMy0wNS0wMlQxMjo1NjowNy4wMDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiZGF0YSI6eyJ0ZXN0X3Byb3BlcnR5X3N0cmluZzMiOiJ2YWx1ZSIsInRlc3RfcHJvcGVydHlfc3RyaW5nIjoidmFsdWUiLCJ0ZXN0X3Byb3BlcnR5X3N0cmluZzQiOiJ2YWx1ZSIsInRlc3RfcHJvcGVydHlfc3RyaW5nMSI6InZhbHVlIiwidGVzdF9wcm9wZXJ0eV9zdHJpbmcyIjoidmFsdWUifX0sImNyZWRlbnRpYWxTY2hlbWEiOnsiaWQiOiJkaWQ6ZXZhbjpFaUJtaUhDSExNYkdWbjlobGxSTTVxUU9zc2h2RVRUb0VBTEJBdEZxUDNQVUlnIiwidHlwZSI6IkV2YW5WQ1NjaGVtYSJ9LCJjcmVkZW50aWFsU3RhdHVzIjp7ImlkIjoiZGlkOmV2YW46cmV2b2NhdGlvbjEyMyMwIiwidHlwZSI6IlJldm9jYXRpb25MaXN0MjAyMVN0YXR1cyIsInJldm9jYXRpb25MaXN0SW5kZXgiOiIwIiwicmV2b2NhdGlvbkxpc3RDcmVkZW50aWFsIjoiZGlkOmV2YW46cmV2b2NhdGlvbjEyMyJ9LCJwcm9vZiI6eyJ0eXBlIjoiQmJzQmxzU2lnbmF0dXJlUHJvb2YyMDIwIiwiY3JlYXRlZCI6IjIwMjMtMDUtMDJUMTI6NTY6MDcuMDAwWiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsImNyZWRlbnRpYWxNZXNzYWdlQ291bnQiOjE3LCJ2ZXJpZmljYXRpb25NZXRob2QiOiJkaWQ6ZXZhbjpFaURtUmtLc09hZXk4dFB6YzZSeVFyWWtNTmpwcVhYVlRqOWdneTBFYmlYUzRnI2Jicy1rZXktMSIsIm5vbmNlIjoiUmVuNGtvQ2g2bElEZWVWT0RiZXNyZC9uWmo1cnZmNVVqMW9yQytNeXhLWT0iLCJwcm9vZiI6IkFBQURYTGFLc0pJcnpoSW9lcE9VYkxveGlZa2JWVFY1bFpGaDRxWlRWU3BlZ0paalp4UFgrdFo1UnBSY0pJWGlKN0htQ280T0hPYzVnTERORThXeW5wSU4rMHdLTUNtNjArWElCYzV2VExWb1paU3RmazhJQ0M2ZXJua3ZiUTY0K1ZpY1ZJTVk1NGVEU0U4VkpWMUo3UGt3a2RrS0RFeFA0N2VlUnlkcVE4NVV1N0ZqOUlRT0gyTFpQRHhIczdRQ1dUeE95QUFBQUhTeFRndlowd3ZmTmFNa3dwakdCcFVPcTVhNmVnc2NFajlpTlVlV0pDNnRTN0M4WTBTWW9ncjA0bkZIQ0ZXVHpSNEFBQUFDUGNOVEhaN3RDbzNFZStGd1B5SVZ0dUZpNkkrdDJCNURJSEU2RkM1YXlwRmowanBFa2hnbmJueHlvdUFab1hiSkQxMkpNQXkveUJ4M2J5c3UyL2dNSjVCV1dwait1Tzh2bTJyY1J5YWF4b2VQVXk5YlI1S21Oa1F6cUZnbWFzam1aT2VsSzRWK29zZkh1ampjV1FXaUZnQUFBQkZmOW84NWpnb2I1L3g2MTcxaXZ4d293eHlzQkNGVm9xbkJSK042SlZsZjJuRWUzeWtPMmtGSXZETnd5S2doMGlYWkdkaFZhWVR1ZTZlSlEwUVp6d1E2Vk1pYTUxRmZkaUdYZjRId3RkMTRDL0Uwb2xoc2NwdkZ4SlBOSWJLZnRqRW9nZ0lnM2VNWFZNWEREL0thMjl1ellKM0liTCtqM2kvOEt6eUlkMU8va2pzV1VMeFowZ3YxOXlsSXcvUzVuNGpPYzBSRTFWNVdZbi9NZmxPM1RYaXhYLzVPckxXUTRmWm9FbUc4RzhWdFZud0NheDQvek9NREhLaURiM2hlc2Exdyt3QVhEcnJmN2lVSEFJV1dQL0cwT1UwYUZiZWhMS21LanZVYlRIeXkvZ3dmWXhjT0hyaWhxOUxmOG1TWGF6amdaT3VIdlNCWWIrWGRtd1Rpb0graEtwWHc3Q3d1YUsyOTZPa2Q5ZGV5dzVGSmIyZ2xScXNoSmI1dHJYM1FWM3BiSzlHZkJETDhGUzNLTWdaS00rR09nNlgxVFlPRkM2VzB3MXBqYjRkQThHTnpORGNCclN0U2RVbTB6VXRzbzY4a0JhYkxIeEljeEY3b21zOHRCVzZxRi9GNnpROW1RQUZnRThJdytxNWNuNFY5L1lKRmhxMHZLSUN5bDRJS2RQZFl5am1OZUI4NnZtWGkzWFBnM0ZNSTFCdDBTWWdXT3hkZ3dBNDdQU3BkRmw0Wnd6bFBDdWc3ZHYxTVBQOVFucWNTeUFqaUhLVGtoNERUNEtIV0daVDJTR0RSeGkzcHcxdGZiZXAxVmQvVkFHajd5Uml0aVBSK2h2VkZSaVlQaXpSeW9ZMmZyc1dFZTUwRTJBWnowV2RHV1NRRWlGUTNLR21WbFlIaGVpOUtCbVowTmRUUWpxVTIyL21qbnRCVFpkNlR0MTBCVlZKVmRmelV0VDNJbndVZkFBQUFBZ0FBQUFwYlc4SWZJVzA5YTlhdkNDNmxkQTZpYXFqZnNaajBKcUQ2d0tWT1pab1hCZ0FBQUFzRm51WWE0MUxRcEZtaGhobjR1MnJhWGRXelBzMUNKRisxc1Foc1hPMEtJQT09In19XX0sImlzcyI6ImRpZDpldmFuOnZlcmlmaWVyIn0.3pC8nIGxB9NrENJq7gdMv7edE7fyihDy-5FptUg0kcFrCjgSryj74q7V0oh30bIRRr6PXdpURda4Dh_Pp4peMgA"
-      }
-   }"###;
+        "@context":[
+           "https://www.w3.org/2018/credentials/v1",
+           "https://schema.org/",
+           "https://w3id.org/vc-revocation-list-2020/v1"
+        ],
+        "id":"eef83094-8ac1-498e-857e-9ee616166874",
+        "type":[
+           "VerifiablePresentation"
+        ],
+        "verifiableCredential":[
+           {
+              "@context":[
+                 "https://www.w3.org/2018/credentials/v1",
+                 "https://schema.org/",
+                 "https://w3id.org/vc-revocation-list-2020/v1"
+              ],
+              "id":"uuid:bacd08f9-70c1-400a-b02b-8c25266801fc",
+              "type":[
+                 "VerifiableCredential"
+              ],
+              "issuer":"did:evan:EiDmRkKsOaey8tPzc6RyQrYkMNjpqXXVTj9ggy0EbiXS4g",
+              "issuanceDate":"2023-05-11T09:08:30.000Z",
+              "credentialSubject":{
+                 "data":{
+                    "test_property_string3":"value",
+                    "test_property_string":"value",
+                    "test_property_string2":"value",
+                    "test_property_string1":"value",
+                    "test_property_string4":"value"
+                 }
+              },
+              "credentialSchema":{
+                 "id":"did:evan:EiBmiHCHLMbGVn9hllRM5qQOsshvETToEALBAtFqP3PUIg",
+                 "type":"EvanVCSchema"
+              },
+              "credentialStatus":{
+                 "id":"did:evan:revocation123#0",
+                 "type":"RevocationList2021Status",
+                 "revocationListIndex":"0",
+                 "revocationListCredential":"did:evan:revocation123"
+              },
+              "proof":{
+                 "type":"BbsBlsSignatureProof2020",
+                 "created":"2023-05-11T09:08:30.000Z",
+                 "proofPurpose":"assertionMethod",
+                 "credentialMessageCount":17,
+                 "verificationMethod":"did:evan:EiDmRkKsOaey8tPzc6RyQrYkMNjpqXXVTj9ggy0EbiXS4g#bbs-key-1",
+                 "requiredRevealStatements":[
+                    1
+                 ],
+                 "nonce":"SOl8UwURM8e25OmQdWnuRbjN9odp3VLvIkjoQLKkqKM=",
+                 "proof":"AAADPK/vJrC2jKwaR66pJRln5YEVlBb2ahgk69m+AjWvgMoJIoZcQFJ7q1lt/f5Zyd2YjpAPsyVtD/IUUKJP5AT/o0IENYvowNxwWQpJBmKkg1rh2hZ0wTiW4PDanV68LzPbtIZo52vQov6p1lRV3mPs6xM/fv3aK1hmo1vdwGldMEVy3i7HkXQZh8EVfznigyuenAAAAHSHog3MayRRDrIlHShgZ0rWVazCyy6gJRSI1EyfG2GkeX9lzxnK0/3+4Uh+S+q/+yoAAAACMXz1UD6KLjj0AG0WLS1vIH8pLdOxMHZnZJVJLPtz2yQVZrpu7Vlm9rOrORtUyreXZnVRrJv0U1a5JJtquAJNdpB5AEeUI+Sw7CV/uwlGTwJpVeC7uH0wJvqSNSqK4QxteTpthgYhtOBYYxZakfgL/AAAABAMc/8nNHJ1oqLAP5jeSAWQVU7nRYhmzNvP18rRvqJHCEEkfh0p4oUAoytCjY7dNuYgqt3eN3DdyB2dE82hmddFAjWwjcOBXIbkTaAb7EuFpVyqTmZmhI4f0pGEipZaaypTJKqZAJz7yS5b+pPLHYPws4P9k6BW8QJQiR92p+rztFejcbyVbbbDQfKBq0D3/zeOqnjbfrPpD4GN8qpTJfcgAijXwdhUS8FNPvOw03NhQY9AcSxyourl+iU1uKVbW91cKsiqQyoOVBDppSi59YXcQ2yt41YnfgO1cPTFSgC3FV55OfqGZdAv5J5FuMvMrliiT/BYo/xQkVCysKA03voCB/rpUYhPrEIszGzMz6DaCudSewf36+esRSRY4x4zYmRipJ2tGszZ69L3ymqXrf9sGuyHCX1BXsB3rHo1LSiALzva6XwU5zQjLwypRLh/LLhZcXk+yPgCNfozXXnLvcuILG2GrewSMqfN2pvJF2PoJm4HiriJuM+ToQgDHB82esk8+lz41ehjSY7hJUqHU57oYKvy1w5mjGlIDLRamiwQvgUWwggKdFgN1+PiVhcxVc7HCf1C+ZJ/rzzXMpV70iOXTBu4P2NWLrvu3fjJMrmGNtJkIx1vfF7nAD4z7KUSooEam0PtPvPPUC+f8eg1QDCRbTL+SbcdEVkNExbNfE2SoAAAAAMAAAABFN4XaxUBPChiGzTnZ97Rwp65wHsUo6dM7lQbtDOyNcQAAAAKSL9XmufOj5Sei+rHLru0gEkw73SjwF2aX8iuixs+quEAAAALcNid9ZwC9vrKXg7JI4keNSSF+mgyW8Kz+QgFt255TsM="
+              }
+           }
+        ],
+        "proof":{
+           "type":"EcdsaPublicKeySecp256k1",
+           "created":"2023-05-11T09:08:30.000Z",
+           "proofPurpose":"assertionMethod",
+           "verificationMethod":"did:evan:verifier#key-1",
+           "jws":"eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzI1NkstUiJ9.eyJpYXQiOiIyMDIzLTA1LTExVDA5OjA4OjMwLjAwMFoiLCJkb2MiOnsiQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3NjaGVtYS5vcmcvIiwiaHR0cHM6Ly93M2lkLm9yZy92Yy1yZXZvY2F0aW9uLWxpc3QtMjAyMC92MSJdLCJpZCI6ImVlZjgzMDk0LThhYzEtNDk4ZS04NTdlLTllZTYxNjE2Njg3NCIsInR5cGUiOlsiVmVyaWZpYWJsZVByZXNlbnRhdGlvbiJdLCJ2ZXJpZmlhYmxlQ3JlZGVudGlhbCI6W3siQGNvbnRleHQiOlsiaHR0cHM6Ly93d3cudzMub3JnLzIwMTgvY3JlZGVudGlhbHMvdjEiLCJodHRwczovL3NjaGVtYS5vcmcvIiwiaHR0cHM6Ly93M2lkLm9yZy92Yy1yZXZvY2F0aW9uLWxpc3QtMjAyMC92MSJdLCJpZCI6InV1aWQ6YmFjZDA4ZjktNzBjMS00MDBhLWIwMmItOGMyNTI2NjgwMWZjIiwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCJdLCJpc3N1ZXIiOiJkaWQ6ZXZhbjpFaURtUmtLc09hZXk4dFB6YzZSeVFyWWtNTmpwcVhYVlRqOWdneTBFYmlYUzRnIiwiaXNzdWFuY2VEYXRlIjoiMjAyMy0wNS0xMVQwOTowODozMC4wMDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiZGF0YSI6eyJ0ZXN0X3Byb3BlcnR5X3N0cmluZzQiOiJ2YWx1ZSIsInRlc3RfcHJvcGVydHlfc3RyaW5nMyI6InZhbHVlIiwidGVzdF9wcm9wZXJ0eV9zdHJpbmciOiJ2YWx1ZSIsInRlc3RfcHJvcGVydHlfc3RyaW5nMiI6InZhbHVlIiwidGVzdF9wcm9wZXJ0eV9zdHJpbmcxIjoidmFsdWUifX0sImNyZWRlbnRpYWxTY2hlbWEiOnsiaWQiOiJkaWQ6ZXZhbjpFaUJtaUhDSExNYkdWbjlobGxSTTVxUU9zc2h2RVRUb0VBTEJBdEZxUDNQVUlnIiwidHlwZSI6IkV2YW5WQ1NjaGVtYSJ9LCJjcmVkZW50aWFsU3RhdHVzIjp7ImlkIjoiZGlkOmV2YW46cmV2b2NhdGlvbjEyMyMwIiwidHlwZSI6IlJldm9jYXRpb25MaXN0MjAyMVN0YXR1cyIsInJldm9jYXRpb25MaXN0SW5kZXgiOiIwIiwicmV2b2NhdGlvbkxpc3RDcmVkZW50aWFsIjoiZGlkOmV2YW46cmV2b2NhdGlvbjEyMyJ9LCJwcm9vZiI6eyJ0eXBlIjoiQmJzQmxzU2lnbmF0dXJlUHJvb2YyMDIwIiwiY3JlYXRlZCI6IjIwMjMtMDUtMTFUMDk6MDg6MzAuMDAwWiIsInByb29mUHVycG9zZSI6ImFzc2VydGlvbk1ldGhvZCIsImNyZWRlbnRpYWxNZXNzYWdlQ291bnQiOjE3LCJ2ZXJpZmljYXRpb25NZXRob2QiOiJkaWQ6ZXZhbjpFaURtUmtLc09hZXk4dFB6YzZSeVFyWWtNTmpwcVhYVlRqOWdneTBFYmlYUzRnI2Jicy1rZXktMSIsInJlcXVpcmVkUmV2ZWFsU3RhdGVtZW50cyI6WzFdLCJub25jZSI6IlNPbDhVd1VSTThlMjVPbVFkV251UmJqTjlvZHAzVkx2SWtqb1FMS2txS009IiwicHJvb2YiOiJBQUFEUEsvdkpyQzJqS3dhUjY2cEpSbG41WUVWbEJiMmFoZ2s2OW0rQWpXdmdNb0pJb1pjUUZKN3ExbHQvZjVaeWQyWWpwQVBzeVZ0RC9JVVVLSlA1QVQvbzBJRU5Zdm93Tnh3V1FwSkJtS2tnMXJoMmhaMHdUaVc0UERhblY2OEx6UGJ0SVpvNTJ2UW92NnAxbFJWM21QczZ4TS9mdjNhSzFobW8xdmR3R2xkTUVWeTNpN0hrWFFaaDhFVmZ6bmlneXVlbkFBQUFIU0hvZzNNYXlSUkRySWxIU2hnWjByV1ZhekN5eTZnSlJTSTFFeWZHMkdrZVg5bHp4bkswLzMrNFVoK1MrcS8reW9BQUFBQ01YejFVRDZLTGpqMEFHMFdMUzF2SUg4cExkT3hNSFpuWkpWSkxQdHoyeVFWWnJwdTdWbG05ck9yT1J0VXlyZVhablZSckp2MFUxYTVKSnRxdUFKTmRwQjVBRWVVSStTdzdDVi91d2xHVHdKcFZlQzd1SDB3SnZxU05TcUs0UXh0ZVRwdGhnWWh0T0JZWXhaYWtmZ0wvQUFBQUJBTWMvOG5OSEoxb3FMQVA1amVTQVdRVlU3blJZaG16TnZQMThyUnZxSkhDRUVrZmgwcDRvVUFveXRDalk3ZE51WWdxdDNlTjNEZHlCMmRFODJobWRkRkFqV3dqY09CWElia1RhQWI3RXVGcFZ5cVRtWm1oSTRmMHBHRWlwWmFheXBUSktxWkFKejd5UzViK3BQTEhZUHdzNFA5azZCVzhRSlFpUjkycCtyenRGZWpjYnlWYmJiRFFmS0JxMEQzL3plT3FuamJmclBwRDRHTjhxcFRKZmNnQWlqWHdkaFVTOEZOUHZPdzAzTmhRWTlBY1N4eW91cmwraVUxdUtWYlc5MWNLc2lxUXlvT1ZCRHBwU2k1OVlYY1EyeXQ0MVluZmdPMWNQVEZTZ0MzRlY1NU9mcUdaZEF2NUo1RnVNdk1ybGlpVC9CWW8veFFrVkN5c0tBMDN2b0NCL3JwVVloUHJFSXN6R3pNejZEYUN1ZFNld2YzNitlc1JTUlk0eDR6WW1SaXBKMnRHc3paNjlMM3ltcVhyZjlzR3V5SENYMUJYc0IzckhvMUxTaUFMenZhNlh3VTV6UWpMd3lwUkxoL0xMaFpjWGsreVBnQ05mb3pYWG5MdmN1SUxHMkdyZXdTTXFmTjJwdkpGMlBvSm00SGlyaUp1TStUb1FnREhCODJlc2s4K2x6NDFlaGpTWTdoSlVxSFU1N29ZS3Z5MXc1bWpHbElETFJhbWl3UXZnVVd3Z2dLZEZnTjErUGlWaGN4VmM3SENmMUMrWkovcnp6WE1wVjcwaU9YVEJ1NFAyTldMcnZ1M2ZqSk1ybUdOdEprSXgxdmZGN25BRDR6N0tVU29vRWFtMFB0UHZQUFVDK2Y4ZWcxUURDUmJUTCtTYmNkRVZrTkV4Yk5mRTJTb0FBQUFBTUFBQUFCRk40WGF4VUJQQ2hpR3pUblo5N1J3cDY1d0hzVW82ZE03bFFidERPeU5jUUFBQUFLU0w5WG11Zk9qNVNlaStySExydTBnRWt3NzNTandGMmFYOGl1aXhzK3F1RUFBQUFMY05pZDlad0M5dnJLWGc3Skk0a2VOU1NGK21neVc4S3orUWdGdDI1NVRzTT0ifX1dfSwiaXNzIjoiZGlkOmV2YW46dmVyaWZpZXIifQ.DZ_7YdG2ONbNZx7vuxD2BOGshj_RAuvitcW2xDMCYn5UNVbs72ZiWkUBM6MdTVF9vTF9IjbXrISWgJOmeaejIwA"
+        }
+     }"###;
 
     pub const PROOF_PRESENTATION_INVALID_SIGNATURE_AND_WITHOUT_JWS: &str = r###"{
-        "@context": [
-            "https://www.w3.org/2018/credentials/v1",
-            "https://schema.org/",
-            "https://w3id.org/vc-revocation-list-2020/v1"
+        "@context":[
+           "https://www.w3.org/2018/credentials/v1",
+           "https://schema.org/",
+           "https://w3id.org/vc-revocation-list-2020/v1"
         ],
-        "id": "743875ce-8ec0-4b6a-a67d-33a64392a5d3",
-        "type": [
-            "VerifiablePresentation"
+        "id":"eef83094-8ac1-498e-857e-9ee616166874",
+        "type":[
+           "VerifiablePresentation"
         ],
-        "verifiableCredential": [
-            {
-                "@context": [
-                    "https://www.w3.org/2018/credentials/v1",
-                    "https://schema.org/",
-                    "https://w3id.org/vc-revocation-list-2020/v1"
-                ],
-                "id": "uuid:94450c72-5dc4-4e46-8df0-106819064656",
-                "type": [
-                    "VerifiableCredential"
-                ],
-                "issuer": "did:evan:EiDmRkKsOaey8tPzc6RyQrYkMNjpqXXVTj9ggy0EbiXS4g",
-                "issuanceDate": "2023-03-22T15:42:23.000Z",
-                "credentialSubject": {
-                    "data": {
-                        "test_property_string4": "value",
-                        "test_property_string": "value",
-                        "test_property_string2": "value",
-                        "test_property_string3": "value",
-                        "test_property_string1": "value"
-                    }
-                },
-                "credentialSchema": {
-                    "id": "did:evan:EiAn35ScK8_GsBE9GwMFC5BwvjZXkxEWIfmi6hAoCzvA0w",
-                    "type": "EvanZKPSchema"
-                },
-                "credentialStatus": {
-                    "id": "did:evan:revocation123#0",
-                    "type": "RevocationList2021Status",
-                    "revocationListIndex": "0",
-                    "revocationListCredential": "did:evan:revocation123"
-                },
-                "proof": {
-                    "type": "BbsBlsSignatureProof2020",
-                    "created": "2023-03-22T15:42:23.000Z",
-                    "proofPurpose": "assertionMethod",
-                    "credentialMessageCount": 17,
-                    "requiredRevealStatements":[1],
-                    "verificationMethod": "did:evan:EiDmRkKsOaey8tPzc6RyQrYkMNjpqXXVTj9ggy0EbiXS4g#bbs-key-1",
-                    "nonce": "XxApxRDBXaF0QCXHh7zMS7Ms2ELVcBUc0TdhfaAzH8o=",
-                    "proof": "BBBCHKtugFHiaXgjrnI+pyfT6f3J5fGUQDJh0JfDsbH0kurhMMdVUkB3gIUCFLksvRm1Ca8o+LkqLH4/lEcVGOd1aldGNsAw5IyEPmeWReYDPLSJroqSPdecEk8bLYbRR/SDno7FWUMUYOovWi/3jAyo7lrNlf4rKJW+2FRgvlf8HzWwaZhk1dB5uynsRIrwnDjqjwAAAHSEMZIcRYIj+fsVov2nt40lhyumTCdK0rlqDjIs1MHAJqNoWhrxqIFp5w6iZfYTlzoAAAACIWxKnfGSrrDg26fcm01ky3Wr1hCJ8I9PuuQ7SBpbaYhNprKueXJeMlIMCa1ocLiaWwurNikj4sfhtp3FnihEjYMUnP6MpwrZNKWYEVWID8y06YSaQDvC1bc3wfmB4GB0t9aIjl9ubYrKxgL3d4gtVwAAAAdc8Zq55QJ5MRHapXd4g3eC1jaLBYWe+SBP19phXorOQSTu1qcWuiIEE6A8mwW9pMeTDOyFoaJwooD8HNLgh0hIFEHHx9ou0YHql7KCbtN0XrxMNJLhU/EABWp8XJJFxKkH2uYXy5/T6wbuO5TQSuDrl7foiuETyEAfDDKD+zgVPmt5MUIgzWASShvaNZ7cQ22Oct8/w4vyQJpA38/3oMvJN/tp72vz2z1D7Qu9f4K73peEY3OnhYo0EW2jqjhJER8ngeHozTH85yX29uDI6T0zi8dMJEq80ijBlgLwCf9TqgAAAAEAAAABVYYuxWfEuaxvBkivWA/SfIa+XSWTfQxphjVs8yhmpfY="
+        "verifiableCredential":[
+           {
+              "@context":[
+                 "https://www.w3.org/2018/credentials/v1",
+                 "https://schema.org/",
+                 "https://w3id.org/vc-revocation-list-2020/v1"
+              ],
+              "id":"uuid:bacd08f9-70c1-400a-b02b-8c25266801fc",
+              "type":[
+                 "VerifiableCredential"
+              ],
+              "issuer":"did:evan:EiDmRkKsOaey8tPzc6RyQrYkMNjpqXXVTj9ggy0EbiXS4g",
+              "issuanceDate":"2023-05-11T09:08:30.000Z",
+              "credentialSubject":{
+                 "data":{
+                    "test_property_string3":"value",
+                    "test_property_string":"value",
+                    "test_property_string2":"value",
+                    "test_property_string1":"value",
+                    "test_property_string4":"value"
+                 }
+              },
+              "credentialSchema":{
+                 "id":"did:evan:EiBmiHCHLMbGVn9hllRM5qQOsshvETToEALBAtFqP3PUIg",
+                 "type":"EvanVCSchema"
+              },
+              "credentialStatus":{
+                 "id":"did:evan:revocation123#0",
+                 "type":"RevocationList2021Status",
+                 "revocationListIndex":"0",
+                 "revocationListCredential":"did:evan:revocation123"
+              },
+              "proof":{
+                 "type":"BbsBlsSignatureProof2020",
+                 "created":"2023-05-11T09:08:30.000Z",
+                 "proofPurpose":"assertionMethod",
+                 "credentialMessageCount":17,
+                 "verificationMethod":"did:evan:EiDmRkKsOaey8tPzc6RyQrYkMNjpqXXVTj9ggy0EbiXS4g#bbs-key-1",
+                 "requiredRevealStatements":[
+                    1
+                 ],
+                 "nonce":"SOl8UwURM8e25OmQdWnuRbjN9odp3VLvIkjoQLKkqKM=",
+                 "proof": "BBBCHKtugFHiaXgjrnI+pyfT6f3J5fGUQDJh0JfDsbH0kurhMMdVUkB3gIUCFLksvRm1Ca8o+LkqLH4/lEcVGOd1aldGNsAw5IyEPmeWReYDPLSJroqSPdecEk8bLYbRR/SDno7FWUMUYOovWi/3jAyo7lrNlf4rKJW+2FRgvlf8HzWwaZhk1dB5uynsRIrwnDjqjwAAAHSEMZIcRYIj+fsVov2nt40lhyumTCdK0rlqDjIs1MHAJqNoWhrxqIFp5w6iZfYTlzoAAAACIWxKnfGSrrDg26fcm01ky3Wr1hCJ8I9PuuQ7SBpbaYhNprKueXJeMlIMCa1ocLiaWwurNikj4sfhtp3FnihEjYMUnP6MpwrZNKWYEVWID8y06YSaQDvC1bc3wfmB4GB0t9aIjl9ubYrKxgL3d4gtVwAAAAdc8Zq55QJ5MRHapXd4g3eC1jaLBYWe+SBP19phXorOQSTu1qcWuiIEE6A8mwW9pMeTDOyFoaJwooD8HNLgh0hIFEHHx9ou0YHql7KCbtN0XrxMNJLhU/EABWp8XJJFxKkH2uYXy5/T6wbuO5TQSuDrl7foiuETyEAfDDKD+zgVPmt5MUIgzWASShvaNZ7cQ22Oct8/w4vyQJpA38/3oMvJN/tp72vz2z1D7Qu9f4K73peEY3OnhYo0EW2jqjhJER8ngeHozTH85yX29uDI6T0zi8dMJEq80ijBlgLwCf9TqgAAAAEAAAABVYYuxWfEuaxvBkivWA/SfIa+XSWTfQxphjVs8yhmpfY="
                 }
-            }
+           }
         ]
-    }"###;
+     }"###;
 }

--- a/utilities/src/test_data.rs
+++ b/utilities/src/test_data.rs
@@ -410,6 +410,7 @@ pub mod bbs_coherent_context_test_data {
                "created":"2023-05-02T12:56:07.000Z",
                "proofPurpose":"assertionMethod",
                "credentialMessageCount":17,
+               "requiredRevealStatements":[1],
                "verificationMethod":"did:evan:EiDmRkKsOaey8tPzc6RyQrYkMNjpqXXVTj9ggy0EbiXS4g#bbs-key-1",
                "nonce":"Ren4koCh6lIDeeVODbesrd/nZj5rvf5Uj1orC+MyxKY=",
                "proof":"AAADXLaKsJIrzhIoepOUbLoxiYkbVTV5lZFh4qZTVSpegJZjZxPX+tZ5RpRcJIXiJ7HmCo4OHOc5gLDNE8WynpIN+0wKMCm60+XIBc5vTLVoZZStfk8ICC6ernkvbQ64+VicVIMY54eDSE8VJV1J7PkwkdkKDExP47eeRydqQ85Uu7Fj9IQOH2LZPDxHs7QCWTxOyAAAAHSxTgvZ0wvfNaMkwpjGBpUOq5a6egscEj9iNUeWJC6tS7C8Y0SYogr04nFHCFWTzR4AAAACPcNTHZ7tCo3Ee+FwPyIVtuFi6I+t2B5DIHE6FC5aypFj0jpEkhgnbnxyouAZoXbJD12JMAy/yBx3bysu2/gMJ5BWWpj+uO8vm2rcRyaaxoePUy9bR5KmNkQzqFgmasjmZOelK4V+osfHujjcWQWiFgAAABFf9o85jgob5/x6171ivxwowxysBCFVoqnBR+N6JVlf2nEe3ykO2kFIvDNwyKgh0iXZGdhVaYTue6eJQ0QZzwQ6VMia51FfdiGXf4Hwtd14C/E0olhscpvFxJPNIbKftjEoggIg3eMXVMXDD/Ka29uzYJ3IbL+j3i/8KzyId1O/kjsWULxZ0gv19ylIw/S5n4jOc0RE1V5WYn/MflO3TXixX/5OrLWQ4fZoEmG8G8VtVnwCax4/zOMDHKiDb3hesa1w+wAXDrrf7iUHAIWWP/G0OU0aFbehLKmKjvUbTHyy/gwfYxcOHrihq9Lf8mSXazjgZOuHvSBYb+XdmwTioH+hKpXw7CwuaK296Okd9deyw5FJb2glRqshJb5trX3QV3pbK9GfBDL8FS3KMgZKM+GOg6X1TYOFC6W0w1pjb4dA8GNzNDcBrStSdUm0zUtso68kBabLHxIcxF7oms8tBW6qF/F6zQ9mQAFgE8Iw+q5cn4V9/YJFhq0vKICyl4IKdPdYyjmNeB86vmXi3XPg3FMI1Bt0SYgWOxdgwA47PSpdFl4ZwzlPCug7dv1MPP9QnqcSyAjiHKTkh4DT4KHWGZT2SGDRxi3pw1tfbep1Vd/VAGj7yRitiPR+hvVFRiYPizRyoY2frsWEe50E2AZz0WdGWSQEiFQ3KGmVlYHhei9KBmZ0NdTQjqU22/mjntBTZd6Tt10BVVJVdfzUtT3InwUfAAAAAgAAAApbW8IfIW09a9avCC6ldA6iaqjfsZj0JqD6wKVOZZoXBgAAAAsFnuYa41LQpFmhhhn4u2raXdWzPs1CJF+1sQhsXO0KIA=="
@@ -472,6 +473,7 @@ pub mod bbs_coherent_context_test_data {
                     "created": "2023-03-22T15:42:23.000Z",
                     "proofPurpose": "assertionMethod",
                     "credentialMessageCount": 17,
+                    "requiredRevealStatements":[1],
                     "verificationMethod": "did:evan:EiDmRkKsOaey8tPzc6RyQrYkMNjpqXXVTj9ggy0EbiXS4g#bbs-key-1",
                     "nonce": "XxApxRDBXaF0QCXHh7zMS7Ms2ELVcBUc0TdhfaAzH8o=",
                     "proof": "BBBCHKtugFHiaXgjrnI+pyfT6f3J5fGUQDJh0JfDsbH0kurhMMdVUkB3gIUCFLksvRm1Ca8o+LkqLH4/lEcVGOd1aldGNsAw5IyEPmeWReYDPLSJroqSPdecEk8bLYbRR/SDno7FWUMUYOovWi/3jAyo7lrNlf4rKJW+2FRgvlf8HzWwaZhk1dB5uynsRIrwnDjqjwAAAHSEMZIcRYIj+fsVov2nt40lhyumTCdK0rlqDjIs1MHAJqNoWhrxqIFp5w6iZfYTlzoAAAACIWxKnfGSrrDg26fcm01ky3Wr1hCJ8I9PuuQ7SBpbaYhNprKueXJeMlIMCa1ocLiaWwurNikj4sfhtp3FnihEjYMUnP6MpwrZNKWYEVWID8y06YSaQDvC1bc3wfmB4GB0t9aIjl9ubYrKxgL3d4gtVwAAAAdc8Zq55QJ5MRHapXd4g3eC1jaLBYWe+SBP19phXorOQSTu1qcWuiIEE6A8mwW9pMeTDOyFoaJwooD8HNLgh0hIFEHHx9ou0YHql7KCbtN0XrxMNJLhU/EABWp8XJJFxKkH2uYXy5/T6wbuO5TQSuDrl7foiuETyEAfDDKD+zgVPmt5MUIgzWASShvaNZ7cQ22Oct8/w4vyQJpA38/3oMvJN/tp72vz2z1D7Qu9f4K73peEY3OnhYo0EW2jqjhJER8ngeHozTH85yX29uDI6T0zi8dMJEq80ijBlgLwCf9TqgAAAAEAAAABVYYuxWfEuaxvBkivWA/SfIa+XSWTfQxphjVs8yhmpfY="


### PR DESCRIPTION
## Description
This mr enables support for required_revealed_statements indices in Credential proof for presentation creation and verify presentation functionalities.

## Details
- Added support for required_revealed_statements in vc_zkp_offer_credential payload
- Added support for required_revealed_statements in present_proof function for presentation creation
- Added support for required_revealed_statements in verify_proof function for presentation verification
- Adjusted structs 
- Adjusted test cases