### PR TITLE
Add checks to ensure credential uuids start with `uuid:`

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -8,6 +8,15 @@
 
 ### Deprecations
 
+- the field `id` is now using a struct to wrap (de)serialization (`PrefixedUuid`) and its value must now be prefixed with `uuid:` in `DraftBbsCredential` and therefore in:
+  - `OfferCredentialPayload`
+  - `RequestCredentialPayload`
+  - `IssueCredentialPayload`
+  - `BbsCredential`
+  - `UnsignedBbsCredential`
+  - `UnfinishedBbsCredential`
+  - `BbsPresentation`
+
 ## v0.4.0
 
 ### Features

--- a/src/application/datatypes.rs
+++ b/src/application/datatypes.rs
@@ -105,9 +105,7 @@ impl CredentialSchema {
                 "https://schema.org/".to_string(),
                 "https://w3id.org/vc-revocation-list-2020/v1".to_string(),
             ],
-            id: options.id.unwrap_or_else(|| {
-                PrefixedUuid(format!("uuid:{}", Uuid::new_v4()))
-            }),
+            id: options.id.unwrap_or_else(|| PrefixedUuid::new(Uuid::new_v4().to_string())),
             r#type: vec!["VerifiableCredential".to_string()],
             issuer: options.issuer_did,
             valid_until: options.valid_until,
@@ -502,11 +500,30 @@ impl RevocationListCredential {
     }
 }
 
+/// Helper class to ensure that credential id uuid's are prefixed with `"uuid:"`.
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(try_from = "String")]
 pub struct PrefixedUuid(String);
 
 impl PrefixedUuid {
+    /// Creates a new `PrefixedUuid` by either taking given uuid as is or prefixing it with `"uuid:"` if required.
+    ///
+    /// # Arguments
+    ///
+    /// * `uuid` - uuid string to use as value
+    pub fn new(uuid: String) -> Self {
+        if uuid.starts_with("uuid:") {
+            Self(uuid)
+        } else {
+            Self(format!("uuid:{}", &uuid))
+        }
+    }
+
+    /// Tries to create a new `PrefixedUuid` instance, will fail if missing the `"uuid:"` prefix. Used for parsing uuids.
+    ///
+    /// # Arguments
+    ///
+    /// * `uuid` - uuid string to use as value
     pub fn try_new(uuid: String) -> Result<Self, String> {
         if uuid.starts_with("uuid:") {
             Ok(Self(uuid))

--- a/src/application/datatypes.rs
+++ b/src/application/datatypes.rs
@@ -16,7 +16,7 @@
 
 use bbs::{ProofNonce, SignatureProof, ToVariableLengthBytes};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, error::Error};
+use std::{collections::HashMap, convert::TryFrom, error::Error, fmt::Display};
 use uuid::Uuid;
 
 use super::{issuer::ADDITIONAL_HIDDEN_MESSAGES_COUNT, utils::get_now_as_iso_string};
@@ -88,7 +88,7 @@ pub struct CredentialSchema {
 
 pub struct CredentialDraftOptions {
     pub issuer_did: String,
-    pub id: Option<String>,
+    pub id: Option<PrefixedUuid>,
     pub issuance_date: Option<String>,
     pub valid_until: Option<String>,
 }
@@ -105,9 +105,9 @@ impl CredentialSchema {
                 "https://schema.org/".to_string(),
                 "https://w3id.org/vc-revocation-list-2020/v1".to_string(),
             ],
-            id: options
-                .id
-                .unwrap_or_else(|| format!("uuid:{}", Uuid::new_v4())),
+            id: options.id.unwrap_or_else(|| {
+                PrefixedUuid(format!("uuid:{}", Uuid::new_v4()))
+            }),
             r#type: vec!["VerifiableCredential".to_string()],
             issuer: options.issuer_did,
             valid_until: options.valid_until,
@@ -178,7 +178,7 @@ pub struct CredentialProposal {
 pub struct BbsCredential {
     #[serde(rename(serialize = "@context", deserialize = "@context"))]
     pub context: Vec<String>,
-    pub id: String,
+    pub id: PrefixedUuid,
     pub r#type: Vec<String>,
     pub issuer: String,
     pub issuance_date: String,
@@ -226,7 +226,7 @@ impl BbsCredential {
 pub struct UnsignedBbsCredential {
     #[serde(rename(serialize = "@context", deserialize = "@context"))]
     pub context: Vec<String>,
-    pub id: String,
+    pub id: PrefixedUuid,
     pub r#type: Vec<String>,
     pub issuer: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -253,7 +253,7 @@ impl UnsignedBbsCredential {
 pub struct UnfinishedBbsCredential {
     #[serde(rename(serialize = "@context", deserialize = "@context"))]
     pub context: Vec<String>,
-    pub id: String,
+    pub id: PrefixedUuid,
     pub r#type: Vec<String>,
     pub issuer: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -391,7 +391,7 @@ pub struct UnfinishedProofPresentation {
 pub struct BbsPresentation {
     #[serde(rename(serialize = "@context", deserialize = "@context"))]
     pub context: Vec<String>,
-    pub id: String,
+    pub id: PrefixedUuid,
     pub r#type: Vec<String>,
     pub issuer: String,
     pub issuance_date: String,
@@ -502,12 +502,51 @@ impl RevocationListCredential {
     }
 }
 
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(try_from = "String")]
+pub struct PrefixedUuid(String);
+
+impl PrefixedUuid {
+    pub fn try_new(uuid: String) -> Result<Self, String> {
+        if uuid.starts_with("uuid:") {
+            Ok(Self(uuid))
+        } else {
+            Err(format!(
+                r#"uuid must start with prefix "uuid:" but got: "{}""#,
+                uuid
+            ))
+        }
+    }
+
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+
+    pub fn inner(&self) -> &String {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for PrefixedUuid {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        PrefixedUuid::try_new(value)
+    }
+}
+
+impl Display for PrefixedUuid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct DraftBbsCredential {
     #[serde(rename(serialize = "@context", deserialize = "@context"))]
     pub context: Vec<String>,
-    pub id: String,
+    pub id: PrefixedUuid,
     pub r#type: Vec<String>,
     pub issuer: String,
     pub issuance_date: String,
@@ -524,7 +563,7 @@ impl DraftBbsCredential {
     ) -> UnsignedBbsCredential {
         UnsignedBbsCredential {
             context: self.context.clone(),
-            id: self.id.to_owned(),
+            id: self.id.clone(),
             r#type: self.r#type.clone(),
             issuer: self.issuer.to_owned(),
             valid_until: self.valid_until.to_owned(),
@@ -582,5 +621,132 @@ impl LdProofVcDetail {
         };
 
         Ok(message_count)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate utilities;
+
+    use serde_json::Value;
+    use utilities::test_data::bbs_coherent_context_test_data::{
+        FINISHED_CREDENTIAL,
+        PROOF_PRESENTATION,
+        UNFINISHED_CREDENTIAL,
+        UNSIGNED_CREDENTIAL,
+    };
+
+    use crate::{BbsCredential, ProofPresentation, UnfinishedBbsCredential, UnsignedBbsCredential};
+
+    #[test]
+    fn can_parse_a_credential_with_a_valid_uuid() -> Result<(), Box<dyn std::error::Error>> {
+        let result: Result<BbsCredential, serde_json::Error> =
+            serde_json::from_str(&FINISHED_CREDENTIAL);
+
+        assert!(&result.is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn cannot_parse_a_credential_with_an_invalid_uuid() -> Result<(), Box<dyn std::error::Error>> {
+        let mut credential: Value = serde_json::from_str(&FINISHED_CREDENTIAL)?;
+        credential["id"] = Value::String("733ae398-ca4e-45e8-a420-a602b1ab9131".to_string());
+        let serialized_with_invalid_id = serde_json::to_string(&credential)?;
+
+        let result: Result<BbsCredential, serde_json::Error> =
+            serde_json::from_str(&serialized_with_invalid_id);
+
+        assert!(&result.is_err());
+        let error_message = format!("{}", &result.err().unwrap());
+        assert!(error_message.starts_with(r#"uuid must start with prefix "uuid:""#));
+
+        Ok(())
+    }
+
+    #[test]
+    fn can_parse_an_unsigned_credential_with_a_valid_uuid() -> Result<(), Box<dyn std::error::Error>> {
+        let result: Result<UnsignedBbsCredential, serde_json::Error> =
+            serde_json::from_str(&UNSIGNED_CREDENTIAL);
+
+        assert!(&result.is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn cannot_parse_an_unsigned_credential_with_an_invalid_uuid() -> Result<(), Box<dyn std::error::Error>> {
+        let mut credential: Value = serde_json::from_str(&UNSIGNED_CREDENTIAL)?;
+        credential["id"] = Value::String("733ae398-ca4e-45e8-a420-a602b1ab9131".to_string());
+        let serialized_with_invalid_id = serde_json::to_string(&credential)?;
+
+        let result: Result<UnsignedBbsCredential, serde_json::Error> =
+            serde_json::from_str(&serialized_with_invalid_id);
+
+        assert!(&result.is_err());
+        let error_message = format!("{}", &result.err().unwrap());
+        assert!(error_message.starts_with(r#"uuid must start with prefix "uuid:""#));
+
+        Ok(())
+    }
+
+    #[test]
+    fn can_parse_an_unfinished_credential_with_a_valid_uuid() -> Result<(), Box<dyn std::error::Error>> {
+        let result: Result<UnfinishedBbsCredential, serde_json::Error> =
+            serde_json::from_str(&UNFINISHED_CREDENTIAL);
+
+        assert!(&result.is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn cannot_parse_an_unfinished_credential_with_an_invalid_uuid() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let mut credential: Value = serde_json::from_str(&UNFINISHED_CREDENTIAL)?;
+        credential["id"] = Value::String("733ae398-ca4e-45e8-a420-a602b1ab9131".to_string());
+        let serialized_with_invalid_id = serde_json::to_string(&credential)?;
+
+        let result: Result<UnfinishedBbsCredential, serde_json::Error> =
+            serde_json::from_str(&serialized_with_invalid_id);
+
+        assert!(&result.is_err());
+        let error_message = format!("{}", &result.err().unwrap());
+        assert!(error_message.starts_with(r#"uuid must start with prefix "uuid:""#));
+
+        Ok(())
+    }
+
+    #[test]
+    fn can_parse_a_proof_presentation_with_a_valid_uuid() -> Result<(), Box<dyn std::error::Error>> {
+        let result: Result<ProofPresentation, serde_json::Error> =
+            serde_json::from_str(&PROOF_PRESENTATION);
+
+        assert!(&result.is_ok());
+
+        Ok(())
+    }
+
+    #[test]
+    fn cannot_parse_a_proof_presentation_with_an_invalid_uuid() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let mut proof_presentation: Value = serde_json::from_str(&PROOF_PRESENTATION)?;
+        proof_presentation["verifiableCredential"]
+            .as_array_mut()
+            .ok_or_else(|| "could not get verifiableCredential array".to_string())?[0]
+            .as_object_mut()
+            .ok_or_else(|| "could not get the first verifiableCredential object".to_string())?
+            ["id"] =
+            Value::String("733ae398-ca4e-45e8-a420-a602b1ab9131".to_string());
+        let serialized_with_invalid_id = serde_json::to_string(&proof_presentation)?;
+
+        let result: Result<ProofPresentation, serde_json::Error> =
+            serde_json::from_str(&serialized_with_invalid_id);
+
+        assert!(&result.is_err());
+        let error_message = format!("{}", &result.err().unwrap());
+        assert!(error_message.starts_with(r#"uuid must start with prefix "uuid:""#));
+
+        Ok(())
     }
 }

--- a/src/application/issuer.rs
+++ b/src/application/issuer.rs
@@ -45,6 +45,7 @@ use crate::{
     LdProofVcDetailOptionsCredentialStatus,
     LdProofVcDetailOptionsCredentialStatusType,
     LdProofVcDetailOptionsType,
+    PrefixedUuid,
 };
 use bbs::{
     issuer::Issuer as BbsIssuer,
@@ -309,7 +310,7 @@ impl Issuer {
             blind_signature: base64::encode(blind_signature.to_bytes_compressed_form()),
         };
 
-        let credential_id = format!("uuid:{}", generate_uuid());
+        let credential_id = PrefixedUuid::try_new(generate_uuid())?;
         let credential = UnfinishedBbsCredential {
             context: DEFAULT_CREDENTIAL_CONTEXTS
                 .iter()

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -930,7 +930,8 @@ mod tests {
     fn get_offer_payload_with_id(id: &str) -> String {
         r###"{
             "draftCredential": $DRAFT_CREDENTIAL,
-            "credentialStatusType": "RevocationList2021Status"
+            "credentialStatusType": "RevocationList2021Status",
+            "requiredRevealStatements": [1]
         }"###
             .replace("$DRAFT_CREDENTIAL", &create_draft_credential_with_id(id))
     }
@@ -973,7 +974,8 @@ mod tests {
                         "proofType": "Ed25519Signature2018",
                         "credentialStatus": {
                             "type": "RevocationList2021Status"
-                        }
+                        },
+                        "requiredRevealStatements": [1]
                     }
                 },
                 "nonce": "nonce"
@@ -1012,7 +1014,8 @@ mod tests {
                             "proofType": "Ed25519Signature2018",
                             "credentialStatus": {
                                 "type": "RevocationList2021Status"
-                            }
+                            },
+                            "requiredRevealStatements": [1]
                         }
                     },
                     "nonce": "nonce"
@@ -1047,7 +1050,8 @@ mod tests {
                             "proofType": "Ed25519Signature2018",
                             "credentialStatus": {
                                 "type": "RevocationList2021Status"
-                            }
+                            },
+                            "requiredRevealStatements": [1]
                         }
                     },
                     "nonce": "nonce"

--- a/utilities/src/test_data.rs
+++ b/utilities/src/test_data.rs
@@ -154,7 +154,7 @@ pub mod bbs_coherent_context_test_data {
            "https://schema.org/",
            "https://w3id.org/vc-revocation-list-2020/v1"
         ],
-        "id":"94450c72-5dc4-4e46-8df0-106819064656",
+        "id":"uuid:94450c72-5dc4-4e46-8df0-106819064656",
         "type":[
            "VerifiableCredential"
         ],


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Add checks to ensure credential uuids start with `uuid:` to make sure we only create credentials, that can be safely parsed into NQUADS later on.

## Details

<!--- HOW does it change stuff? -->

- the field `id` is now using a struct to wrap (de)serialization (`PrefixedUuid`) and its value must now be prefixed with `uuid:` in `DraftBbsCredential` and therefore in:
  - `OfferCredentialPayload`
  - `RequestCredentialPayload`
  - `IssueCredentialPayload`
  - `BbsCredential`
  - `UnsignedBbsCredential`
  - `UnfinishedBbsCredential`
  - `BbsPresentation`

## Impact on Rollout/Usage

<!-- Delete points, that do not apply. Add comments to those that apply. -->
- `vade-evan` has to be updated after this merge request to make sure correct types for id fields are used