### PR TITLE
fix revocation credential size

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -22,7 +22,7 @@
 ### Fixes
 
 - update dependencies for critical vulnerabilities
-- add support for `required_reveal_statements` in `vade-evan-bbs`
+- fix credential size is increasing when revoking, because old proof was not removed before
 
 ## v0.3.0
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -22,6 +22,7 @@
 ### Fixes
 
 - update dependencies for critical vulnerabilities
+- add support for `required_reveal_statements` in `vade-evan-bbs`
 
 ## v0.3.0
 


### PR DESCRIPTION
## Description

Current Revocation of credential increases size of updated `RevocationCredential` as it adds a new proof everytime without deleting old proof, This Mr fixes this.

## Details 

- Removes proof before signing a new credential
- Add test for verification
