### PR TITLE
Add support for proof proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,8 +2409,7 @@ dependencies = [
 [[package]]
 name = "vade"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c510deb9534df9da15a2dce4602d1601a5ec9cf231293adffc0b39bfe877dc"
+source = "git+https://github.com/evannetwork/vade?branch=feature/add-proof-proposals#a573ec5b65b8ca03a0536da22aa906e5970579a2"
 dependencies = [
  "async-trait",
  "env_logger",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,8 +2408,9 @@ dependencies = [
 
 [[package]]
 name = "vade"
-version = "0.1.0"
-source = "git+https://github.com/evannetwork/vade?branch=feature/add-proof-proposals#a573ec5b65b8ca03a0536da22aa906e5970579a2"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e358313f2c726a5d6d7c8253a5f708f0d2dcca7c3606a7e4e2a5e94a9fd808"
 dependencies = [
  "async-trait",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ sha2 = "0.8.1"
 sha3 = "0.8.2"
 ssi-json-ld = "0.1.0"
 uuid = { version = "0.8.1", features = ["serde", "v4", "wasm-bindgen"] }
-vade = "0.1.0"
+# vade = "0.1.0"
+vade = { git = "https://github.com/evannetwork/vade", branch = "feature/add-proof-proposals" }
 vade-signer = { git = "https://github.com/evannetwork/vade-signer", branch = "develop" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,7 @@ sha2 = "0.8.1"
 sha3 = "0.8.2"
 ssi-json-ld = "0.1.0"
 uuid = { version = "0.8.1", features = ["serde", "v4", "wasm-bindgen"] }
-# vade = "0.1.0"
-vade = { git = "https://github.com/evannetwork/vade", branch = "feature/add-proof-proposals" }
+vade = "0.1.1"
 vade-signer = { git = "https://github.com/evannetwork/vade-signer", branch = "develop" }
 
 [dev-dependencies]

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,9 @@
 
 ### Features
 
+- add `vc_zkp_propose_proof` to add propose step, that can be done before requesting proofs
+- add support to accept `BbsProofProposal` as input for `vc_zkp_request_proof`
+
 ### Fixes
 
 ### Deprecations

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -220,8 +220,8 @@ pub struct RequestProofPayloadFromScratch {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", untagged)]
 pub enum RequestProofPayload {
-    CreateRequestArgs(RequestProofPayloadFromScratch),
-    Offer(BbsProofProposal),
+    FromScratch(RequestProofPayloadFromScratch),
+    FromOffer(BbsProofProposal),
 }
 
 /// API payload to revoke a credential as this credential's issuer.
@@ -765,11 +765,11 @@ impl VadePlugin for VadeEvanBbs {
         ignore_unrelated!(method, options);
         let payload: RequestProofPayload = parse!(&payload, "payload");
         let result: BbsProofRequest = match payload {
-            RequestProofPayload::Offer(mut offer) => {
+            RequestProofPayload::FromOffer(mut offer) => {
                 offer.created_at = get_now_as_iso_string();
                 offer.into()
             }
-            RequestProofPayload::CreateRequestArgs(args) => Verifier::create_proof_request(
+            RequestProofPayload::FromScratch(args) => Verifier::create_proof_request(
                 args.verifier_did,
                 args.schemas,
                 args.reveal_attributes,

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -221,7 +221,7 @@ pub struct RequestProofPayloadFromScratch {
 #[serde(rename_all = "camelCase", untagged)]
 pub enum RequestProofPayload {
     FromScratch(RequestProofPayloadFromScratch),
-    FromOffer(BbsProofProposal),
+    FromProposal(BbsProofProposal),
 }
 
 /// API payload to revoke a credential as this credential's issuer.
@@ -765,7 +765,7 @@ impl VadePlugin for VadeEvanBbs {
         ignore_unrelated!(method, options);
         let payload: RequestProofPayload = parse!(&payload, "payload");
         let result: BbsProofRequest = match payload {
-            RequestProofPayload::FromOffer(mut offer) => {
+            RequestProofPayload::FromProposal(mut offer) => {
                 offer.created_at = get_now_as_iso_string();
                 offer.into()
             }

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -151,7 +151,7 @@ fn empty_array() -> Vec<u32> {
 pub struct ProposeProofPayload {
     /// DID of the verifier
     pub verifier_did: Option<String>,
-    /// List of schema IDs to request
+    /// List of schema IDs to propose
     pub schemas: Vec<String>,
     /// Attributes to reveal per schema ID
     pub reveal_attributes: HashMap<String, Vec<usize>>,
@@ -637,9 +637,9 @@ impl VadePlugin for VadeEvanBbs {
     }
 
     /// Proposes a proof for one or more credentials issued under one or more specific schemas and
-    /// is sent by a verifier to a prover.
+    /// is sent by a prover to a verifier.
     ///
-    /// The proof proposal consists of the fields the issuer wants to reveal per schema.
+    /// The proof proposal consists of the fields the holder wants to reveal per schema.
     ///
     /// # Arguments
     ///
@@ -657,7 +657,6 @@ impl VadePlugin for VadeEvanBbs {
     ) -> Result<VadePluginResultValue<Option<String>>, Box<dyn Error>> {
         ignore_unrelated!(method, options);
 
-        ignore_unrelated!(method, options);
         let payload: ProposeProofPayload = parse!(&payload, "payload");
         let result: BbsProofProposal = Verifier::create_proof_request(
             payload.verifier_did,
@@ -744,7 +743,7 @@ impl VadePlugin for VadeEvanBbs {
     /// Requests a proof for one or more credentials issued under one or more specific schemas and
     /// is sent by a verifier to a prover.
     ///
-    /// Proof request can be created from scratch or by using a proof offering as an input argument.
+    /// Proof request can be created from scratch or by using a proof proposal as an input argument.
     ///
     /// The proof request consists of the fields the verifier wants to be revealed per schema.
     ///

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -145,7 +145,7 @@ fn empty_array() -> Vec<u32> {
     [].into()
 }
 
-/// API payload to create a BbsProofProposal to be sent by a verifier.
+/// API payload to create a BbsProofProposal to be sent by a holder.
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProposeProofPayload {

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -198,17 +198,33 @@ async fn create_finished_credential(
     Ok(finished_credential)
 }
 
-async fn create_proof_request(vade: &mut Vade) -> Result<BbsProofRequest, Box<dyn Error>> {
+async fn create_proof_request_from_scratch(
+    vade: &mut Vade,
+) -> Result<BbsProofRequest, Box<dyn Error>> {
     let mut reveal_attributes = HashMap::new();
     reveal_attributes.insert(SCHEMA_DID.clone().to_string(), vec![1]);
-    let proof_request_payload = RequestProofPayload {
-        verifier_did: Some(VERIFIER_DID.to_string()),
-        schemas: vec![SCHEMA_DID.to_string()],
-        reveal_attributes,
-    };
+    let proof_request_payload =
+        RequestProofPayload::CreateRequestArgs(RequestProofPayloadFromScratch {
+            verifier_did: Some(VERIFIER_DID.to_string()),
+            schemas: vec![SCHEMA_DID.to_string()],
+            reveal_attributes,
+        });
     let proof_request_json = serde_json::to_string(&proof_request_payload)?;
     let result = vade
         .vc_zkp_request_proof(EVAN_METHOD, TYPE_OPTIONS, &proof_request_json)
+        .await?;
+    let proof_request: BbsProofRequest = serde_json::from_str(&result[0].as_ref().unwrap())?;
+
+    Ok(proof_request)
+}
+
+async fn create_proof_request_from_proposal(
+    vade: &mut Vade,
+    proposal: &BbsProofProposal,
+) -> Result<BbsProofRequest, Box<dyn Error>> {
+    let payload = serde_json::to_string(&proposal)?;
+    let result = vade
+        .vc_zkp_request_proof(EVAN_METHOD, TYPE_OPTIONS, &payload)
         .await?;
     let proof_request: BbsProofRequest = serde_json::from_str(&result[0].as_ref().unwrap())?;
 
@@ -658,8 +674,94 @@ async fn workflow_can_propose_request_issue_verify_a_credential() -> Result<(), 
     )
     .await?;
     // create proof request
-    let mut proof_request = create_proof_request(&mut vade).await?;
+    let mut proof_request = create_proof_request_from_scratch(&mut vade).await?;
     proof_request.sub_proof_requests[0].revealed_attributes = vec![10, 11];
+
+    // create proof
+    let mut public_key_schema_map = HashMap::new();
+    public_key_schema_map.insert(SCHEMA_DID.to_string(), PUB_KEY.to_string());
+    let presentation = create_presentation(
+        &mut vade,
+        finished_credential.clone(),
+        proof_request.clone(),
+        public_key_schema_map.clone(),
+    )
+    .await?;
+    // verify proof
+    let verify_proof_payload = VerifyProofPayload {
+        presentation: presentation.clone(),
+        proof_request: proof_request.clone(),
+        keys_to_schema_map: public_key_schema_map,
+        signer_address: SIGNER_1_ADDRESS.to_string(),
+        revocation_list: Some(revocation_list.clone()),
+    };
+    let verify_proof_json = serde_json::to_string(&verify_proof_payload)?;
+    let results = vade
+        .vc_zkp_verify_proof(EVAN_METHOD, TYPE_OPTIONS, &verify_proof_json)
+        .await?;
+
+    let result: BbsProofVerification =
+        serde_json::from_str(&results[0].as_ref().ok_or("could not get result")?)?;
+
+    assert_eq!(&result.presented_proof, &presentation.id);
+    assert_eq!(&result.status, &"verified".to_string());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn workflow_can_propose_request_issue_verify_a_credential_with_proof_proposal(
+) -> Result<(), Box<dyn Error>> {
+    let mut vade = get_vade();
+
+    let revocation_list = create_revocation_list(&mut vade).await?;
+
+    // Create credential offering
+    let schema = CredentialSchema::from_str(SCHEMA)?;
+    let mut credential_draft = schema.to_draft_credential(CredentialDraftOptions {
+        issuer_did: ISSUER_DID.to_string(),
+        id: None,
+        issuance_date: None,
+        valid_until: None,
+    });
+    let mut credential_values = HashMap::new();
+    credential_values.insert("test_property_string3".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string1".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string2".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string4".to_owned(), "value".to_owned());
+    credential_draft.credential_subject.data = credential_values;
+    let offer_payload = OfferCredentialPayload {
+        draft_credential: credential_draft,
+        credential_status_type:
+            LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
+        required_reveal_statements: vec![1],
+    };
+
+    let offer = create_credential_offer(&mut vade, offer_payload).await?;
+    let (credential_request, signature_blinding_base64) =
+        create_credential_request(&mut vade, offer.clone()).await?;
+
+    let unfinished_credential = create_unfinished_credential(
+        &mut vade,
+        credential_request,
+        Some(revocation_list.id.clone()),
+        Some("0".to_string()),
+    )
+    .await?;
+    let finished_credential = create_finished_credential(
+        &mut vade,
+        unfinished_credential.clone(),
+        signature_blinding_base64.clone(),
+    )
+    .await?;
+
+    // create proof request, that we'll use for a proposal
+    let proof_request_draft = create_proof_request_from_scratch(&mut vade).await?;
+    let proof_proposal: BbsProofProposal = proof_request_draft.into();
+
+    // create proof request, that we'll use to create the proof
+    let proof_request = create_proof_request_from_proposal(&mut vade, &proof_proposal).await?;
 
     // create proof
     let mut public_key_schema_map = HashMap::new();
@@ -742,7 +844,7 @@ async fn workflow_cannot_verify_revoked_credential() -> Result<(), Box<dyn Error
     let updated_revocation = revoke_credential(&mut vade, revocation_list, "0".to_string()).await?;
 
     // create proof request
-    let proof_request = create_proof_request(&mut vade).await?;
+    let proof_request = create_proof_request_from_scratch(&mut vade).await?;
 
     // create proof
     let mut public_key_schema_map = HashMap::new();
@@ -859,7 +961,7 @@ async fn workflow_can_not_verify_presentation_mismatch_revealed_statements(
     )
     .await?;
     // create proof request
-    let mut proof_request = create_proof_request(&mut vade).await?;
+    let mut proof_request = create_proof_request_from_scratch(&mut vade).await?;
     proof_request.sub_proof_requests[0].revealed_attributes = vec![10, 11];
 
     // create proof
@@ -948,7 +1050,7 @@ async fn workflow_can_not_verify_presentation_mismatch_required_revealed_stateme
     )
     .await?;
     // create proof request
-    let mut proof_request = create_proof_request(&mut vade).await?;
+    let mut proof_request = create_proof_request_from_scratch(&mut vade).await?;
     proof_request.sub_proof_requests[0].revealed_attributes = vec![10, 11];
 
     // create proof

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -203,12 +203,11 @@ async fn create_proof_request_from_scratch(
 ) -> Result<BbsProofRequest, Box<dyn Error>> {
     let mut reveal_attributes = HashMap::new();
     reveal_attributes.insert(SCHEMA_DID.clone().to_string(), vec![1]);
-    let proof_request_payload =
-        RequestProofPayload::CreateRequestArgs(RequestProofPayloadFromScratch {
-            verifier_did: Some(VERIFIER_DID.to_string()),
-            schemas: vec![SCHEMA_DID.to_string()],
-            reveal_attributes,
-        });
+    let proof_request_payload = RequestProofPayload::FromScratch(RequestProofPayloadFromScratch {
+        verifier_did: Some(VERIFIER_DID.to_string()),
+        schemas: vec![SCHEMA_DID.to_string()],
+        reveal_attributes,
+    });
     let proof_request_json = serde_json::to_string(&proof_request_payload)?;
     let result = vade
         .vc_zkp_request_proof(EVAN_METHOD, TYPE_OPTIONS, &proof_request_json)

--- a/typings/application/datatypes.d.ts
+++ b/typings/application/datatypes.d.ts
@@ -25,6 +25,20 @@ export interface BbsCredentialRequest {
 }
 
 /**
+ * Message sent by a prover stating which attributes of which schema he is intending to reveal.
+ *
+ * All fields (except `createdAt`) will be included in a `BbsProofRequest` created from this proposal.
+ */
+export interface BbsProofProposal {
+  verifier: string;
+  createdAt: string;
+  nonce: string;
+  type: string;
+  subProofRequests: BbsSubProofRequest[];
+}
+
+
+/**
  * Message sent by a verifier stating which attributes of which schema the prover is supposed to reveal.
  */
 export interface BbsProofRequest {

--- a/typings/vade_evan_bbs.d.ts
+++ b/typings/vade_evan_bbs.d.ts
@@ -24,12 +24,12 @@ import {
   CredentialStatus,
   CredentialSubject,
   DraftBbsCredential,
-  LdProofVcDetail,
   ProofPresentation,
   RevocationListCredential,
   SchemaProperty,
   UnfinishedBbsCredential,
   LdProofVcDetailOptionsCredentialStatusType,
+  BbsProofProposal,
 } from './application/datatypes';
 
 /** Message passed to vade containing the desired credential type.
@@ -127,8 +127,8 @@ export interface RequestCredentialPayload {
   credentialSchema: CredentialSchema;
 }
 
-/** API payload to create a BbsProofRequest to be sent by a verifier. */
-export interface RequestProofPayload {
+/** API payload to create a BbsProofProposal to be sent by a holder. */
+export interface ProposeProofPayload {
   /** DID of the verifier */
   verifierDid?: string;
   /** List of schema IDs to request */
@@ -136,6 +136,19 @@ export interface RequestProofPayload {
   /** Attributes to reveal per schema ID */
   revealAttributes: Record<string, number[]>;
 }
+
+/** API payload to create a BbsProofRequest if flow starts with request. */
+export interface RequestProofPayloadFromScratch {
+  /** DID of the verifier */
+  verifierDid?: string;
+  /** List of schema IDs to request */
+  schemas: string[];
+  /** Attributes to reveal per schema ID */
+  revealAttributes: Record<string, number[]>;
+}
+
+/** API payload to create a BbsProofRequest to be sent by a verifier. */
+export type RequestProofPayload = RequestProofPayloadFromScratch | BbsProofProposal;
 
 /** API payload to revoke a credential as this credential's issuer. */
 export interface RevokeCredentialPayload {


### PR DESCRIPTION
Adds support to create proof proposals as precursors for proof requests.

## Details

- proof proposals use the same data format as proof requests
- they can be passed as input argument instead of the (still supported) args to create a proof request from scratch)
- if creating a proof request via proof proposal, all values except `createAt` will be copied over to the proof request

## Impact on Rollout/Usage

- typings have to be published after merging PR