### PR TITLE
Update `IssueCredentialPayload` typings

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -9,6 +9,8 @@
 
 ### Fixes
 
+- adjust `credentialStatus` to be optional property in TypeScript typings for `IssueCredentialPayload`
+
 ### Deprecations
 
 ## v0.4.0

--- a/typings/vade_evan_bbs.d.ts
+++ b/typings/vade_evan_bbs.d.ts
@@ -65,7 +65,7 @@ export interface IssueCredentialPayload {
   /** credential request */
   credentialRequest: BbsCredentialRequest;
   /** status to be appended to credential in offer */
-  credentialStatus: CredentialStatus;
+  credentialStatus?: CredentialStatus;
   /** DID url of the public key of the issuer used to later verify the signature */
   issuerPublicKeyId: string;
   /** The public bbs+ key of the issuer used to later verify the signature */


### PR DESCRIPTION
This PR makes `credentialStatus` in `IssueCredentialPayload` typings now optional.