### PR TITLE
Make proof genration/verification optional

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,6 +6,7 @@
 
 - add `vc_zkp_propose_proof` to add propose step, that can be done before requesting proofs
 - add support to accept `BbsProofProposal` as input for `vc_zkp_request_proof`
+- make proof in `ProofPresentation` optional and skip proof verification if not provided
 
 ### Fixes
 

--- a/src/application/datatypes.rs
+++ b/src/application/datatypes.rs
@@ -398,13 +398,13 @@ pub struct ProofPresentation {
     pub id: String,
     pub r#type: Vec<String>,
     pub verifiable_credential: Vec<BbsPresentation>,
-    pub proof: AssertionProof,
+    pub proof: Option<AssertionProof>,
 }
 
 impl ProofPresentation {
     pub fn new(
         unsigned_proof_presentation: UnfinishedProofPresentation,
-        proof: AssertionProof,
+        proof: Option<AssertionProof>,
     ) -> ProofPresentation {
         return ProofPresentation {
             context: unsigned_proof_presentation.context,

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -172,11 +172,11 @@ pub struct PresentProofPayload {
     /// Prover's master secret
     pub master_secret: String,
     /// DID of the prover
-    pub prover_did: String,
+    pub prover_did: Option<String>,
     /// Key DID of the prover's public key for the created assertion proof
-    pub prover_public_key_did: String,
+    pub prover_public_key_did: Option<String>,
     /// Prover's secret key to create an assertion proof with
-    pub prover_proving_key: String,
+    pub prover_proving_key: Option<String>,
 }
 
 /// API payload to create a credential proposal to be sent by a holder.
@@ -624,9 +624,9 @@ impl VadePlugin for VadeEvanBbs {
             &public_key_schema_map,
             &nquads_schema_map,
             &master_secret,
-            &payload.prover_did,
-            &payload.prover_public_key_did,
-            &payload.prover_proving_key,
+            payload.prover_did.as_deref(),
+            payload.prover_public_key_did.as_deref(),
+            payload.prover_proving_key.as_deref(),
             &self.signer,
         )
         .await?;

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -275,9 +275,9 @@ async fn create_presentation(
         public_key_schema_map: public_key_schema_map.clone(),
         revealed_properties_schema_map,
         master_secret: MASTER_SECRET.to_string(),
-        prover_did: VERIFIER_DID.to_string(),
-        prover_public_key_did: format!("{}#key-1", VERIFIER_DID),
-        prover_proving_key: SIGNER_1_PRIVATE_KEY.to_string(),
+        prover_did: Some(VERIFIER_DID.to_string()),
+        prover_public_key_did: Some(format!("{}#key-1", VERIFIER_DID)),
+        prover_proving_key: Some(SIGNER_1_PRIVATE_KEY.to_string()),
     };
 
     let present_proof_json = serde_json::to_string(&present_proof_payload)?;


### PR DESCRIPTION
## Description

This Mr makes assertion proof generation/verification optional and skips it if prover keys and did are not provided, 

## Details

- make prover keys and Did in `PresentProofPayload` optional
- skip proof generation if prover properties are None
- skip proof check if proof not present in presentaiton

