### PR TITLE
Make proofs optional for request list credentials

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -7,7 +7,7 @@
 - add `vc_zkp_propose_proof` to add propose step, that can be done before requesting proofs
 - add support to accept `BbsProofProposal` as input for `vc_zkp_request_proof`
 - update `vc_zkp_create_revocation_registry_definition` to skip proof generation
-  if `issuer_public_key_did` and `issuer_proving_key` are not provided
+  if `issuer_public_key_did` or `issuer_proving_key` are not provided
 
 ### Fixes
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,7 +6,7 @@
 
 - add `vc_zkp_propose_proof` to add propose step, that can be done before requesting proofs
 - add support to accept `BbsProofProposal` as input for `vc_zkp_request_proof`
-- update `vc_zkp_create_revocation_registry_definition` to skip proof generation
+- update `vc_zkp_create_revocation_registry_definition` and `vc_zkp_revoke_credential` to skip proof generation
   if `issuer_public_key_did` or `issuer_proving_key` are not provided
 
 ### Fixes

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -6,6 +6,8 @@
 
 - add `vc_zkp_propose_proof` to add propose step, that can be done before requesting proofs
 - add support to accept `BbsProofProposal` as input for `vc_zkp_request_proof`
+- update `vc_zkp_create_revocation_registry_definition` to skip proof generation
+  if `issuer_public_key_did` and `issuer_proving_key` are not provided
 
 ### Fixes
 

--- a/src/application/datatypes.rs
+++ b/src/application/datatypes.rs
@@ -514,19 +514,6 @@ pub struct BbsProofVerification {
     pub reason: Option<String>,
 }
 
-/// `RevocationListCredential` without a proof (for internal use only).
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct UnproofedRevocationListCredential {
-    #[serde(rename(serialize = "@context", deserialize = "@context"))]
-    pub context: Vec<String>,
-    pub id: String,
-    pub r#type: Vec<String>,
-    pub issuer: String,
-    pub issued: String,
-    pub credential_subject: RevocationListCredentialSubject,
-}
-
 /// A revocation list credential associating verifiable credential revocation IDs to their revocation status as a bit list. See
 /// <https://w3c-ccg.github.io/vc-status-rl-2020/#revocationlist2020credential>
 #[derive(Serialize, Deserialize, Clone)]
@@ -539,24 +526,8 @@ pub struct RevocationListCredential {
     pub issuer: String,
     pub issued: String,
     pub credential_subject: RevocationListCredentialSubject,
-    pub proof: AssertionProof,
-}
-
-impl RevocationListCredential {
-    pub fn new(
-        list: UnproofedRevocationListCredential,
-        proof: AssertionProof,
-    ) -> RevocationListCredential {
-        RevocationListCredential {
-            context: list.context,
-            id: list.id,
-            r#type: list.r#type,
-            issuer: list.issuer,
-            issued: list.issued,
-            credential_subject: list.credential_subject,
-            proof,
-        }
-    }
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proof: Option<AssertionProof>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/application/datatypes.rs
+++ b/src/application/datatypes.rs
@@ -353,6 +353,16 @@ pub struct RevocationListCredentialSubject {
     pub encoded_list: String,
 }
 
+/// Keys required to generate a proof for a revocation list
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RevocationListProofKeys {
+    /// DID of the issuer's public key used to verify the credential's signature
+    pub issuer_public_key_did: String,
+    /// Private key of the issuer used to sign the credential
+    pub issuer_proving_key: String,
+}
+
 /// Reference to a credential schema.
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src/application/issuer.rs
+++ b/src/application/issuer.rs
@@ -419,7 +419,7 @@ impl Issuer {
             None => None,
         };
 
-        return Ok(revocation_list);
+        Ok(revocation_list)
     }
 
     /// Revokes a credential by flipping the specific index in the given revocation list.

--- a/src/application/verifier.rs
+++ b/src/application/verifier.rs
@@ -469,6 +469,7 @@ mod tests {
         let other_proof =
             serde_json::from_str::<RevocationListCredential>(REVOCATION_LIST_CREDENTIAL)?
                 .proof
+                .ok_or_else(|| format!("test data does not contain proof"))?
                 .jws;
         presentation.proof.jws = other_proof;
 

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -74,16 +74,6 @@ pub struct TypeOptions {
     pub r#type: Option<String>,
 }
 
-/// Contains information necessary to make on-chain transactions (e.g. updating a DID Document).
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AuthenticationOptions {
-    /// Reference to the private key, will be forwarded to external signer if available
-    pub private_key: String,
-    /// DID of the identity
-    pub identity: String,
-}
-
 /// API payload needed to create a revocation list
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -366,7 +356,7 @@ impl VadePlugin for VadeEvanBbs {
     /// Runs a custom function, currently supports
     ///
     /// - `create_master_secret` to create new master secrets
-    /// - `create_new_keys` to create a new key pair for BBS+ based signatures and persist  this in the given identity's DID document
+    /// - `create_new_keys` to create a new key pair for BBS+ based signatures
     ///
     /// # Arguments
     ///
@@ -402,8 +392,6 @@ impl VadePlugin for VadeEvanBbs {
     }
 
     /// Creates a new zero-knowledge proof credential schema.
-    ///
-    /// Note that `options.identity` needs to be whitelisted for this function.
     ///
     /// # Arguments
     ///
@@ -444,8 +432,6 @@ impl VadePlugin for VadeEvanBbs {
     /// Creates a new revocation list and stores it on-chain. The list consists of a encoded bit list which can
     /// hold up to 131,072 revokable ids. The list is GZIP encoded and will be updated on every revocation.
     /// The output is a W3C credential with a JWS signature by the given key.
-    ///
-    /// Note that `options.identity` needs to be whitelisted for this function.
     ///
     /// # Arguments
     ///
@@ -784,8 +770,6 @@ impl VadePlugin for VadeEvanBbs {
     /// Revokes a credential. The information returned by this function needs to be persisted in order to update the revocation list. To revoke a credential, the revoker must be in possession of the private key associated
     /// with the credential's revocation list. After revocation, the published revocation list is updated on-chain.
     /// Only then is the credential truly revoked.
-    ///
-    /// Note that `options.identity` needs to be whitelisted for this function.
     ///
     /// # Arguments
     ///

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -69,6 +69,27 @@ async fn create_revocation_list(
     Ok(result)
 }
 
+async fn create_revocation_list_without_proof(
+    vade: &mut Vade,
+) -> Result<RevocationListCredential, Box<dyn Error>> {
+    let payload = format!(
+        r###"{{
+        "issuerDid": "{}",
+        "credentialDid": "did:evan:revocation123"
+    }}"###,
+        ISSUER_DID
+    );
+    let results = vade
+        .vc_zkp_create_revocation_registry_definition(EVAN_METHOD, &get_options(), &payload)
+        .await?;
+
+    // check results
+    assert_eq!(results.len(), 1);
+    let result: RevocationListCredential =
+        serde_json::from_str(results[0].as_ref().unwrap()).unwrap();
+    Ok(result)
+}
+
 fn get_options() -> String {
     format!(
         r###"{{
@@ -232,15 +253,38 @@ async fn create_proof_request_from_proposal(
 
 async fn revoke_credential(
     vade: &mut Vade,
-    revocation_list: RevocationListCredential,
+    revocation_list: &RevocationListCredential,
     revocation_list_id: String,
 ) -> Result<RevocationListCredential, Box<dyn Error>> {
     let revoke_credential_payload = RevokeCredentialPayload {
         issuer: ISSUER_DID.to_string(),
-        revocation_list: revocation_list,
+        revocation_list: revocation_list.clone(),
         revocation_id: revocation_list_id.to_string(),
-        issuer_public_key_did: ISSUER_PUBLIC_KEY_DID.to_string(),
-        issuer_proving_key: ISSUER_PRIVATE_KEY.to_string(),
+        revocation_list_proof_keys: Some(RevocationListProofKeys {
+            issuer_public_key_did: ISSUER_PUBLIC_KEY_DID.to_string(),
+            issuer_proving_key: ISSUER_PRIVATE_KEY.to_string(),
+        }),
+    };
+    let revoke_credential_json = serde_json::to_string(&revoke_credential_payload)?;
+    let updated_revocation_result = vade
+        .vc_zkp_revoke_credential(EVAN_METHOD, &get_options(), &revoke_credential_json)
+        .await?[0]
+        .clone();
+    Ok(serde_json::from_str(
+        &updated_revocation_result.ok_or("Return value was empty")?,
+    )?)
+}
+
+async fn revoke_credential_without_keys(
+    vade: &mut Vade,
+    revocation_list: &RevocationListCredential,
+    revocation_list_id: String,
+) -> Result<RevocationListCredential, Box<dyn Error>> {
+    let revoke_credential_payload = RevokeCredentialPayload {
+        issuer: ISSUER_DID.to_string(),
+        revocation_list: revocation_list.clone(),
+        revocation_id: revocation_list_id.to_string(),
+        revocation_list_proof_keys: None,
     };
     let revoke_credential_json = serde_json::to_string(&revoke_credential_payload)?;
     let updated_revocation_result = vade
@@ -795,6 +839,231 @@ async fn workflow_can_propose_request_issue_verify_a_credential_with_proof_propo
 }
 
 #[tokio::test]
+async fn workflow_can_revoke_a_credential() -> Result<(), Box<dyn Error>> {
+    let mut vade = get_vade();
+
+    let revocation_list = create_revocation_list(&mut vade).await?;
+
+    // Create credential offering
+    let schema = CredentialSchema::from_str(SCHEMA)?;
+    let mut credential_draft = schema.to_draft_credential(CredentialDraftOptions {
+        issuer_did: ISSUER_DID.to_string(),
+        id: None,
+        issuance_date: None,
+        valid_until: None,
+    });
+    let mut credential_values = HashMap::new();
+    credential_values.insert("test_property_string3".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string1".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string2".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string4".to_owned(), "value".to_owned());
+    credential_draft.credential_subject.data = credential_values;
+    let offer_payload = OfferCredentialPayload {
+        draft_credential: credential_draft,
+        credential_status_type:
+            LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
+        required_reveal_statements: vec![1],
+    };
+
+    let offer = create_credential_offer(&mut vade, offer_payload).await?;
+
+    let (credential_request, signature_blinding_base64) =
+        create_credential_request(&mut vade, offer.clone()).await?;
+
+    let unfinished_credential = create_unfinished_credential(
+        &mut vade,
+        credential_request,
+        Some(revocation_list.id.clone()),
+        Some("0".to_string()),
+    )
+    .await?;
+
+    create_finished_credential(&mut vade, unfinished_credential, signature_blinding_base64).await?;
+
+    // revoke credential
+    let updated_revocation =
+        revoke_credential(&mut vade, &revocation_list, "0".to_string()).await?;
+
+    assert_ne!(
+        serde_json::to_string(&revocation_list)?,
+        serde_json::to_string(&updated_revocation)?
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn workflow_can_revoke_a_credential_with_an_unproofed_revocation_list(
+) -> Result<(), Box<dyn Error>> {
+    let mut vade = get_vade();
+
+    let revocation_list = create_revocation_list_without_proof(&mut vade).await?;
+
+    // Create credential offering
+    let schema = CredentialSchema::from_str(SCHEMA)?;
+    let mut credential_draft = schema.to_draft_credential(CredentialDraftOptions {
+        issuer_did: ISSUER_DID.to_string(),
+        id: None,
+        issuance_date: None,
+        valid_until: None,
+    });
+    let mut credential_values = HashMap::new();
+    credential_values.insert("test_property_string3".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string1".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string2".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string4".to_owned(), "value".to_owned());
+    credential_draft.credential_subject.data = credential_values;
+    let offer_payload = OfferCredentialPayload {
+        draft_credential: credential_draft,
+        credential_status_type:
+            LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
+        required_reveal_statements: vec![1],
+    };
+
+    let offer = create_credential_offer(&mut vade, offer_payload).await?;
+
+    let (credential_request, signature_blinding_base64) =
+        create_credential_request(&mut vade, offer.clone()).await?;
+
+    let unfinished_credential = create_unfinished_credential(
+        &mut vade,
+        credential_request,
+        Some(revocation_list.id.clone()),
+        Some("0".to_string()),
+    )
+    .await?;
+
+    create_finished_credential(&mut vade, unfinished_credential, signature_blinding_base64).await?;
+
+    // revoke credential
+    let updated_revocation =
+        revoke_credential(&mut vade, &revocation_list, "0".to_string()).await?;
+
+    assert_ne!(
+        serde_json::to_string(&revocation_list)?,
+        serde_json::to_string(&updated_revocation)?
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn workflow_can_revoke_a_credential_without_providing_keys_during_revocation(
+) -> Result<(), Box<dyn Error>> {
+    let mut vade = get_vade();
+
+    let revocation_list = create_revocation_list(&mut vade).await?;
+
+    // Create credential offering
+    let schema = CredentialSchema::from_str(SCHEMA)?;
+    let mut credential_draft = schema.to_draft_credential(CredentialDraftOptions {
+        issuer_did: ISSUER_DID.to_string(),
+        id: None,
+        issuance_date: None,
+        valid_until: None,
+    });
+    let mut credential_values = HashMap::new();
+    credential_values.insert("test_property_string3".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string1".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string2".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string4".to_owned(), "value".to_owned());
+    credential_draft.credential_subject.data = credential_values;
+    let offer_payload = OfferCredentialPayload {
+        draft_credential: credential_draft,
+        credential_status_type:
+            LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
+        required_reveal_statements: vec![1],
+    };
+
+    let offer = create_credential_offer(&mut vade, offer_payload).await?;
+
+    let (credential_request, signature_blinding_base64) =
+        create_credential_request(&mut vade, offer.clone()).await?;
+
+    let unfinished_credential = create_unfinished_credential(
+        &mut vade,
+        credential_request,
+        Some(revocation_list.id.clone()),
+        Some("0".to_string()),
+    )
+    .await?;
+
+    create_finished_credential(&mut vade, unfinished_credential, signature_blinding_base64).await?;
+
+    // revoke credential
+    let updated_revocation =
+        revoke_credential_without_keys(&mut vade, &revocation_list, "0".to_string()).await?;
+
+    assert_ne!(
+        serde_json::to_string(&revocation_list)?,
+        serde_json::to_string(&updated_revocation)?
+    );
+
+    Ok(())
+}
+
+
+
+#[tokio::test]
+async fn workflow_can_revoke_a_credential_an_unproofed_revocation_list_without_providing_keys_during_revocation(
+) -> Result<(), Box<dyn Error>> {
+    let mut vade = get_vade();
+
+    let revocation_list = create_revocation_list_without_proof(&mut vade).await?;
+
+    // Create credential offering
+    let schema = CredentialSchema::from_str(SCHEMA)?;
+    let mut credential_draft = schema.to_draft_credential(CredentialDraftOptions {
+        issuer_did: ISSUER_DID.to_string(),
+        id: None,
+        issuance_date: None,
+        valid_until: None,
+    });
+    let mut credential_values = HashMap::new();
+    credential_values.insert("test_property_string3".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string1".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string2".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string".to_owned(), "value".to_owned());
+    credential_values.insert("test_property_string4".to_owned(), "value".to_owned());
+    credential_draft.credential_subject.data = credential_values;
+    let offer_payload = OfferCredentialPayload {
+        draft_credential: credential_draft,
+        credential_status_type:
+            LdProofVcDetailOptionsCredentialStatusType::RevocationList2021Status,
+        required_reveal_statements: vec![1],
+    };
+
+    let offer = create_credential_offer(&mut vade, offer_payload).await?;
+
+    let (credential_request, signature_blinding_base64) =
+        create_credential_request(&mut vade, offer.clone()).await?;
+
+    let unfinished_credential = create_unfinished_credential(
+        &mut vade,
+        credential_request,
+        Some(revocation_list.id.clone()),
+        Some("0".to_string()),
+    )
+    .await?;
+
+    create_finished_credential(&mut vade, unfinished_credential, signature_blinding_base64).await?;
+
+    // revoke credential
+    let updated_revocation =
+        revoke_credential_without_keys(&mut vade, &revocation_list, "0".to_string()).await?;
+
+    assert_ne!(
+        serde_json::to_string(&revocation_list)?,
+        serde_json::to_string(&updated_revocation)?
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn workflow_cannot_verify_revoked_credential() -> Result<(), Box<dyn Error>> {
     let mut vade = get_vade();
 
@@ -840,7 +1109,8 @@ async fn workflow_cannot_verify_revoked_credential() -> Result<(), Box<dyn Error
             .await?;
 
     // revoke credential
-    let updated_revocation = revoke_credential(&mut vade, revocation_list, "0".to_string()).await?;
+    let updated_revocation =
+        revoke_credential(&mut vade, &revocation_list, "0".to_string()).await?;
 
     // create proof request
     let proof_request = create_proof_request_from_scratch(&mut vade).await?;

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -21,7 +21,6 @@ use utilities::test_data::{
         ISSUER_PRIVATE_KEY,
         ISSUER_PUBLIC_KEY_DID,
         SIGNER_1_ADDRESS,
-        SIGNER_1_DID,
         SIGNER_1_PRIVATE_KEY,
         VERIFIER_DID,
     },
@@ -91,9 +90,7 @@ async fn create_revocation_list_without_proof(
 }
 
 fn get_options() -> String {
-    r###"{{
-        "type": "bbs",
-    }}"###.to_string()
+    r#"{ "type": "bbs" }"#.to_string()
 }
 
 async fn create_credential_proposal(vade: &mut Vade) -> Result<CredentialProposal, Box<dyn Error>> {

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -91,14 +91,9 @@ async fn create_revocation_list_without_proof(
 }
 
 fn get_options() -> String {
-    format!(
-        r###"{{
-            "type": "bbs",
-            "privateKey": "{}",
-            "identity": "{}"
-        }}"###,
-        SIGNER_1_PRIVATE_KEY, SIGNER_1_DID,
-    )
+    r###"{{
+        "type": "bbs",
+    }}"###.to_string()
 }
 
 async fn create_credential_proposal(vade: &mut Vade) -> Result<CredentialProposal, Box<dyn Error>> {

--- a/typings/application/datatypes.d.ts
+++ b/typings/application/datatypes.d.ts
@@ -267,6 +267,8 @@ export interface BbsProofVerification {
 
 /*
  * `RevocationListCredential` without a proof (for internal use only).
+ *
+ * @deprecated will be removed, use `RevocationListCredential` instead (as `.proof` is optional)
  */
 export interface UnproofedRevocationListCredential {
   '@context': (string | { [key in string]?: { '@type': string } })[];
@@ -288,7 +290,7 @@ export interface RevocationListCredential {
   issuer: string;
   issued: string;
   credentialSubject: RevocationListCredentialSubject;
-  proof: AssertionProof;
+  proof?: AssertionProof;
 }
 
 export interface DraftBbsCredential {

--- a/typings/vade_evan_bbs.d.ts
+++ b/typings/vade_evan_bbs.d.ts
@@ -162,9 +162,9 @@ export interface RevokeCredentialPayload {
   /** Credential ID to revoke */
   revocationId: string;
   /** DID of the issuer's public key for verifying assertion proofs */
-  issuerPublicKeyDid: string;
+  issuerPublicKeyDid?: string;
   /** DID of the issuer's secret key for creating assertion proofs */
-  issuerProvingKey: string;
+  issuerProvingKey?: string;
 }
 
 /** API payload needed to create a credential schema needed for issuing credentials */

--- a/typings/vade_evan_bbs.d.ts
+++ b/typings/vade_evan_bbs.d.ts
@@ -39,7 +39,11 @@ export interface TypeOptions {
   type?: string;
 }
 
-/** Contains information necessary to make on-chain transactions (e.g. updating a DID Document). */
+/**
+ * Contains information necessary to make on-chain transactions (e.g. updating a DID Document).
+ *
+ * @deprecated will be removed as properties from it are not used anymore
+ */
 export interface AuthenticationOptions {
   /** Reference to the private key, will be forwarded to external signer if available */
   privateKey: string;

--- a/typings/vade_evan_bbs.d.ts
+++ b/typings/vade_evan_bbs.d.ts
@@ -47,16 +47,19 @@ export interface AuthenticationOptions {
   identity: string;
 }
 
-/** API payload needed to create a revocation list */
+/** API payload needed to create a revocation list.
+ *
+ * If `issuerPublicKeyDid` or `issuerProvingKey` are omitted, proofs will not be generated for
+ * revocation list credential. */
 export interface CreateRevocationListPayload {
   /** DID of the issuer */
   issuerDid: string;
-  /** DID of the issuer's public key used to verify the credential's signature */
-  issuerPublicKeyDid: string;
-  /** Private key of the issuer used to sign the credential */
-  issuerProvingKey: string;
   /** future did id for revocation list */
   credentialDid: string;
+  /** DID of the issuer's public key used to verify the credential's signature */
+  issuerPublicKeyDid?: string;
+  /** Private key of the issuer used to sign the credential */
+  issuerProvingKey?: string;
 }
 
 /** API payload for issuing a new credential


### PR DESCRIPTION
As revocation list credentials can only be updated by owner, we are able to skip proof generation for them. This MR makes keys optional when creating or updating them.

## Details

- affects `vc_zkp_create_revocation_registry_definition` and `vc_zkp_revoke_credential`
- proof generation is skipped
  if `issuer_public_key_did` or `issuer_proving_key` are not provided
  
## Impact on Rollout/Usage

- as `proof` property is now optional in `RevocationListCredential`, typing for `UnproofedRevocationListCredential` has been marked as deprecated and will be removed in the future