### PR TITLE
Make signer address optional

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -9,6 +9,7 @@
 - make proof in `ProofPresentation` optional and skip proof verification if not provided
 - update `vc_zkp_create_revocation_registry_definition` and `vc_zkp_revoke_credential` to skip proof generation
   if `issuer_public_key_did` or `issuer_proving_key` are not provided
+- update `signer_address` in `VerifyProofPayload` to be optional
 
 ### Fixes
 

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -277,7 +277,7 @@ pub struct VerifyProofPayload {
     /// Relevant BBS+ public keys for each credential schema occurring in this proof
     pub keys_to_schema_map: HashMap<String, String>,
     /// Signer address
-    pub signer_address: String,
+    pub signer_address: Option<String>,
     /// revocation list credential
     pub revocation_list: Option<RevocationListCredential>,
 }
@@ -868,7 +868,7 @@ impl VadePlugin for VadeEvanBbs {
             &payload.presentation,
             &proof_request,
             &public_key_schema_map,
-            &payload.signer_address,
+            payload.signer_address,
             &nquads_schema_map,
         )?;
         if verification_result.status != "rejected" {

--- a/tests/workflows.rs
+++ b/tests/workflows.rs
@@ -727,7 +727,7 @@ async fn workflow_can_propose_request_issue_verify_a_credential() -> Result<(), 
         presentation: presentation.clone(),
         proof_request: proof_request.clone(),
         keys_to_schema_map: public_key_schema_map,
-        signer_address: SIGNER_1_ADDRESS.to_string(),
+        signer_address: Some(SIGNER_1_ADDRESS.to_string()),
         revocation_list: Some(revocation_list.clone()),
     };
     let verify_proof_json = serde_json::to_string(&verify_proof_payload)?;
@@ -813,7 +813,7 @@ async fn workflow_can_propose_request_issue_verify_a_credential_with_proof_propo
         presentation: presentation.clone(),
         proof_request: proof_request.clone(),
         keys_to_schema_map: public_key_schema_map,
-        signer_address: SIGNER_1_ADDRESS.to_string(),
+        signer_address: Some(SIGNER_1_ADDRESS.to_string()),
         revocation_list: Some(revocation_list.clone()),
     };
     let verify_proof_json = serde_json::to_string(&verify_proof_payload)?;
@@ -1124,7 +1124,7 @@ async fn workflow_cannot_verify_revoked_credential() -> Result<(), Box<dyn Error
         presentation,
         proof_request,
         keys_to_schema_map: public_key_schema_map,
-        signer_address: SIGNER_1_ADDRESS.to_string(),
+        signer_address: Some(SIGNER_1_ADDRESS.to_string()),
         revocation_list: Some(updated_revocation),
     };
     let verify_proof_json = serde_json::to_string(&verify_proof_payload)?;
@@ -1243,7 +1243,7 @@ async fn workflow_can_not_verify_presentation_mismatch_revealed_statements(
         presentation: presentation.clone(),
         proof_request: proof_request.clone(),
         keys_to_schema_map: public_key_schema_map,
-        signer_address: SIGNER_1_ADDRESS.to_string(),
+        signer_address: Some(SIGNER_1_ADDRESS.to_string()),
         revocation_list: Some(revocation_list.clone()),
     };
     let verify_proof_json = serde_json::to_string(&verify_proof_payload)?;
@@ -1334,7 +1334,7 @@ async fn workflow_can_not_verify_presentation_mismatch_required_revealed_stateme
         presentation: presentation.clone(),
         proof_request: proof_request.clone(),
         keys_to_schema_map: public_key_schema_map,
-        signer_address: SIGNER_1_ADDRESS.to_string(),
+        signer_address: Some(SIGNER_1_ADDRESS.to_string()),
         revocation_list: Some(revocation_list.clone()),
     };
     let verify_proof_json = serde_json::to_string(&verify_proof_payload)?;


### PR DESCRIPTION
## Description 

Currently proof check in `verify_proof` function is optional but signer_address parameter in `VerifyProofPayload`  is mandatory , this PR makes signer_address param optional so that it is not required to pass if presentation doesn't contain proof. 

## Details

- Update signer_address in `VerifyProofPayload` to be optional
- Add/Update tests
