### PR TITLE
Remove payload from create new keys

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -26,6 +26,8 @@
   - `UnfinishedBbsCredential`
   - `BbsPresentation`
 
+- remove payload parameter from `create_new_keys` custom function
+
 ## v0.4.0
 
 ### Features

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -347,6 +347,7 @@ impl VadePlugin for VadeEvanBbs {
     ///
     /// - `create_master_secret` to create new master secrets
     /// - `create_new_keys` to create a new key pair for BBS+ based signatures
+    /// - `get_public_key_from_private_key` to get the public key from a given private key
     ///
     /// # Arguments
     ///

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -328,10 +328,7 @@ impl VadeEvanBbs {
 }
 
 impl VadeEvanBbs {
-    async fn create_new_keys(
-        &mut self,
-        payload: CreateKeysPayload,
-    ) -> Result<String, Box<dyn Error>> {
+    async fn create_new_keys(&mut self) -> Result<String, Box<dyn Error>> {
         let keys = Issuer::create_new_keys();
         let pub_key = base64::encode(keys.0.to_bytes_compressed_form());
         let secret_key = base64::encode(keys.1.to_bytes_compressed_form());
@@ -340,11 +337,11 @@ impl VadeEvanBbs {
 
         let serialized_keys = format!(
             r###"{{
-                "didUrl": "{}#{}",
+                "keyId": "{}",
                 "publicKey": "{}",
                 "secretKey": "{}"
             }}"###,
-            &payload.key_owner_did, key_id, pub_key, secret_key
+            key_id, pub_key, secret_key
         );
 
         Ok(serialized_keys)
@@ -363,7 +360,7 @@ impl VadePlugin for VadeEvanBbs {
     /// * `method` - method to call a function for (e.g. "did:example")
     /// * `function` - currently supports `create_master_secret` and  `create_new_keys`
     /// * `options` - serialized [`TypeOptions`](https://docs.rs/vade_evan_bbs/*/vade_evan_bbs/struct.TypeOptions.html)
-    /// * `payload` - necessary for `create_new_keys`, can be left empty for `create_master_secret`
+    /// * `payload` - necessary for `get_public_key_from_private_key`, can be left empty for `create_master_secret` and `create_new_keys`
     async fn run_custom_function(
         &mut self,
         method: &str,
@@ -376,12 +373,9 @@ impl VadePlugin for VadeEvanBbs {
             "create_master_secret" => Ok(VadePluginResultValue::Success(Some(
                 serde_json::to_string(&Prover::create_master_secret())?,
             ))),
-            "create_new_keys" => {
-                let payload: CreateKeysPayload = parse!(&payload, "payload");
-                Ok(VadePluginResultValue::Success(Some(
-                    self.create_new_keys(payload).await?,
-                )))
-            }
+            "create_new_keys" => Ok(VadePluginResultValue::Success(Some(
+                self.create_new_keys().await?,
+            ))),
             "get_public_key_from_private_key" => {
                 let payload: GetPublicKeyFromPrivateKeyPayload = parse!(&payload, "payload");
                 let pk_base_64 = get_public_key_from_private_key(&payload.private_key)?;

--- a/src/vade_evan_bbs.rs
+++ b/src/vade_evan_bbs.rs
@@ -282,13 +282,6 @@ pub struct VerifyProofPayload {
     pub revocation_list: Option<RevocationListCredential>,
 }
 
-/// API payload to create new BBS+ keys and persist them on the DID document.
-#[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CreateKeysPayload {
-    pub key_owner_did: String,
-}
-
 /// API payload to derive public key from base 64 encoded private key.
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/typings/vade_evan_bbs.d.ts
+++ b/typings/vade_evan_bbs.d.ts
@@ -88,7 +88,7 @@ export interface OfferCredentialPayload {
   /** credential draft, outlining structure of future credential (without proof and status) */
   draftCredential: DraftBbsCredential;
   /** type of credential status to use; pass`None` to omit status */
-  credentialStatusType: LdProofVcDetailOptionsCredentialStatusType,
+  credentialStatusType: LdProofVcDetailOptionsCredentialStatusType;
   /** defaults to `[]`  */
   requiredRevealStatements?: number[];
 }
@@ -155,7 +155,9 @@ export interface RequestProofPayloadFromScratch {
 }
 
 /** API payload to create a BbsProofRequest to be sent by a verifier. */
-export type RequestProofPayload = RequestProofPayloadFromScratch | BbsProofProposal;
+export type RequestProofPayload =
+  | RequestProofPayloadFromScratch
+  | BbsProofProposal;
 
 /** API payload to revoke a credential as this credential's issuer. */
 export interface RevokeCredentialPayload {
@@ -217,11 +219,6 @@ export interface VerifyProofPayload {
   signerAddress: string;
   /** revocation list credential */
   revocationList?: RevocationListCredential;
-}
-
-/** API payload to create new BBS+ keys and persist them on the DID document. */
-export interface CreateKeysPayload {
-  keyOwnerDid: string;
 }
 
 /** Result of the createKeys method for BBS+ */

--- a/typings/vade_evan_bbs.d.ts
+++ b/typings/vade_evan_bbs.d.ts
@@ -223,8 +223,8 @@ export interface VerifyProofPayload {
 
 /** Result of the createKeys method for BBS+ */
 export interface BbsKeys {
-  /** DID Url of the persisted public key */
-  didUrl: string;
+  /** key id of the persisted public key */
+  keyId: string;
   publicKey: string;
   secretKey: string;
 }


### PR DESCRIPTION
## Description

Remove payload from custom function `create_new_keys` as it is not being used currently

## Details

- Remove unused param
- Update documentation
- Update versions.md
